### PR TITLE
fix: canal Recomendados vacío en la fila de inicio (v2.0.1)

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -4,7 +4,11 @@ on:
   workflow_dispatch:
     inputs:
       release_version:
-        description: 'Versión del release (ej: 2.0.0 o 2.0.0.0)'
+        description: 'Versión del release (ej: 2.0.1 o 2.0.1.0)'
+        required: true
+        type: string
+      changelog:
+        description: 'Notas de la versión (se muestran en el catálogo de Jellyfin y en el release)'
         required: true
         type: string
       prerelease:
@@ -74,8 +78,9 @@ jobs:
           URL="https://github.com/${{ github.repository }}/releases/download/v${{ github.event.inputs.release_version }}/${ZIP}"
           CHECKSUM="${{ steps.package.outputs.checksum }}"
           TS=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-          jq --arg v "$VERSION" --arg url "$URL" --arg sum "$CHECKSUM" --arg ts "$TS" \
-            '.[0].versions = (([.[0].versions[] | select(.version != $v)]) + [{version: $v, changelog: "Ver release notes en GitHub", targetAbi: "10.11.0.0", sourceUrl: $url, checksum: $sum, timestamp: $ts}])' \
+          CHANGELOG="${{ github.event.inputs.changelog }}"
+          jq --arg v "$VERSION" --arg url "$URL" --arg sum "$CHECKSUM" --arg ts "$TS" --arg changelog "$CHANGELOG" \
+            '.[0].versions = (([.[0].versions[] | select(.version != $v)]) + [{version: $v, changelog: $changelog, targetAbi: "10.11.0.0", sourceUrl: $url, checksum: $sum, timestamp: $ts}])' \
             manifest.json > manifest.tmp.json && mv manifest.tmp.json manifest.json
           cp manifest.json publish/manifest.json
 
@@ -91,12 +96,15 @@ jobs:
           git diff --cached --quiet || git commit -m "chore: actualizar manifest a v${{ steps.version.outputs.full }}"
           git push
 
+      - name: Preparar notas del release
+        run: printf '%s' "${{ github.event.inputs.changelog }}" > release-notes.md
+
       - name: Crear release en GitHub
         uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ github.event.inputs.release_version }}
           name: JellyTrend ${{ github.event.inputs.release_version }}
-          generate_release_notes: true
+          body_path: release-notes.md
           prerelease: ${{ github.event.inputs.prerelease }}
           files: |
             Jellyfin.Plugin.JellyTrend-${{ steps.version.outputs.full }}.zip

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <Version>1.0.0.0</Version>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <FileVersion>1.0.0.0</FileVersion>
+    <Version>2.0.1.0</Version>
+    <AssemblyVersion>2.0.1.0</AssemblyVersion>
+    <FileVersion>2.0.1.0</FileVersion>
   </PropertyGroup>
 </Project>

--- a/Jellyfin.Plugin.JellyTrend/Api/RecommendationStorage.cs
+++ b/Jellyfin.Plugin.JellyTrend/Api/RecommendationStorage.cs
@@ -44,6 +44,40 @@ public static class RecommendationStorage
     }
 
     /// <summary>
+    /// Reads the most recently written recommendation file regardless of user. Jellyfin often
+    /// queries channels with an empty user id (Guid.Empty), so a strict per-user lookup would
+    /// return nothing and leave the channel empty. Falling back to any stored file mirrors how
+    /// the Trending channel uses its shared cache: the channel always has content when
+    /// recommendations exist.
+    /// </summary>
+    /// <returns>The stored recommendations, or <c>null</c> when no recommendation file exists.</returns>
+    public static UserRecommendations? ReadAny()
+    {
+        var folder = Folder;
+        if (!Directory.Exists(folder))
+        {
+            return null;
+        }
+
+        var file = Directory.GetFiles(folder, "*.json")
+            .OrderByDescending(File.GetLastWriteTimeUtc)
+            .FirstOrDefault();
+        if (file is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<UserRecommendations>(File.ReadAllText(file));
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
     /// Writes the recommendations for a user.
     /// </summary>
     /// <param name="userId">The user id.</param>

--- a/Jellyfin.Plugin.JellyTrend/Channel/RecommendedChannel.cs
+++ b/Jellyfin.Plugin.JellyTrend/Channel/RecommendedChannel.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.JellyTrend.Api;
@@ -18,6 +19,7 @@ using MediaBrowser.Model.Drawing;
 using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.MediaInfo;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Plugin.JellyTrend.Channel;
@@ -33,6 +35,7 @@ public sealed class RecommendedChannel : IChannel, ISupportsLatestMedia, IRequir
     private readonly ILibraryManager _libraryManager;
     private readonly IMediaSourceManager _mediaSourceManager;
     private readonly IServerApplicationHost _appHost;
+    private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly ILogger<RecommendedChannel> _logger;
 
     /// <summary>
@@ -41,16 +44,19 @@ public sealed class RecommendedChannel : IChannel, ISupportsLatestMedia, IRequir
     /// <param name="libraryManager">Instance of the <see cref="ILibraryManager"/> interface.</param>
     /// <param name="mediaSourceManager">Instance of the <see cref="IMediaSourceManager"/> interface.</param>
     /// <param name="appHost">Instance of the <see cref="IServerApplicationHost"/> interface.</param>
+    /// <param name="httpContextAccessor">Instance of the <see cref="IHttpContextAccessor"/> interface.</param>
     /// <param name="logger">Instance of the <see cref="ILogger{RecommendedChannel}"/> interface.</param>
     public RecommendedChannel(
         ILibraryManager libraryManager,
         IMediaSourceManager mediaSourceManager,
         IServerApplicationHost appHost,
+        IHttpContextAccessor httpContextAccessor,
         ILogger<RecommendedChannel> logger)
     {
         _libraryManager = libraryManager;
         _mediaSourceManager = mediaSourceManager;
         _appHost = appHost;
+        _httpContextAccessor = httpContextAccessor;
         _logger = logger;
     }
 
@@ -138,7 +144,6 @@ public sealed class RecommendedChannel : IChannel, ISupportsLatestMedia, IRequir
         }
 
         var items = BuildChannelItems(query.UserId);
-        _logger.LogDebug("JellyTrend Recomendados: devolviendo {Count} items.", items.Count);
         return Task.FromResult(new ChannelItemResult
         {
             Items = items,
@@ -150,9 +155,12 @@ public sealed class RecommendedChannel : IChannel, ISupportsLatestMedia, IRequir
     public Task<IEnumerable<ChannelItemInfo>> GetLatestMedia(
         ChannelLatestMediaSearch request, CancellationToken cancellationToken)
     {
+        // Both paths go through BuildChannelItems: an unparseable/empty user id falls back
+        // to any stored recommendations (same as the Trending channel), so the row never
+        // reports empty when data exists.
         var items = Guid.TryParse(request.UserId, out var userId)
             ? BuildChannelItems(userId)
-            : [];
+            : BuildChannelItems(Guid.Empty);
         return Task.FromResult<IEnumerable<ChannelItemInfo>>(items);
     }
 
@@ -163,11 +171,38 @@ public sealed class RecommendedChannel : IChannel, ISupportsLatestMedia, IRequir
         return Task.FromResult(ChannelItemFactory.GetMediaInfo(_libraryManager, _mediaSourceManager, id));
     }
 
+    /// <summary>
+    /// Resolves the authenticated user from the current HTTP request. Every Jellyfin client
+    /// sends its access token, so the authenticated user is the real viewer — unlike the
+    /// <c>query.UserId</c> that Jellyfin passes as <see cref="Guid.Empty"/> on the home-row
+    /// refresh. The channel therefore decides by itself what to send to the user.
+    /// </summary>
+    /// <param name="fallback">The user id passed by Jellyfin, used when no authenticated user is available.</param>
+    /// <returns>The authenticated user id when available, otherwise <paramref name="fallback"/>.</returns>
+    private Guid ResolveUserId(Guid fallback)
+    {
+        var http = _httpContextAccessor.HttpContext;
+        var idText = http?.User?.FindFirstValue("Jellyfin-UserId")
+            ?? http?.User?.FindFirstValue(ClaimTypes.NameIdentifier);
+
+        if (!string.IsNullOrEmpty(idText) && Guid.TryParse(idText, out var userId) && userId != Guid.Empty)
+        {
+            return userId;
+        }
+
+        return fallback;
+    }
+
     private List<ChannelItemInfo> BuildChannelItems(Guid userId)
     {
-        var data = RecommendationStorage.Read(userId);
+        // Jellyfin calls the channel with an empty user id (Guid.Empty) on the home-row refresh.
+        // Resolve the authenticated user from the HTTP request instead, falling back to the stored
+        // recommendations only when there is no authenticated context.
+        var resolved = ResolveUserId(userId);
+        var data = RecommendationStorage.Read(resolved) ?? RecommendationStorage.ReadAny();
         if (data is null || data.ItemIds.Count == 0)
         {
+            _logger.LogDebug("JellyTrend Recomendados: sin datos para userId={UserId} (archivo ausente o vacío).", resolved);
             return [];
         }
 
@@ -183,6 +218,7 @@ public sealed class RecommendedChannel : IChannel, ISupportsLatestMedia, IRequir
             result.Add(ChannelItemFactory.BuildMovieItem(_libraryManager, _appHost, item, null, null));
         }
 
+        _logger.LogDebug("JellyTrend Recomendados: leídos {Total} ids, devueltos {Count} para userId={UserId}.", data.ItemIds.Count, result.Count, resolved);
         return result;
     }
 }

--- a/Jellyfin.Plugin.JellyTrend/Channel/TrendingChannel.cs
+++ b/Jellyfin.Plugin.JellyTrend/Channel/TrendingChannel.cs
@@ -223,7 +223,7 @@ public sealed class TrendingChannel : IChannel, IRequiresMediaInfoCallback, ISup
             result.Add(BuildMovieChannelItem(item, cacheItem));
         }
 
-        _logger.LogInformation("JellyTrend Canal: {Count} títulos en el canal.", result.Count);
+        _logger.LogDebug("JellyTrend Canal: {Count} títulos en el canal.", result.Count);
         return result;
     }
 

--- a/Jellyfin.Plugin.JellyTrend/Web/jellyTrend.css
+++ b/Jellyfin.Plugin.JellyTrend/Web/jellyTrend.css
@@ -314,17 +314,27 @@
 /* ── Responsive ──────────────────────────────────────────── */
 @media (max-width: 700px) {
     .jt-section {
+        /* Altura hero en móvil: 28vw era minúsculo en pantallas angostas.
+           Ahora domina la altura de la pantalla (52vh) con mínimo de 230px. */
+        --jt-height: clamp(230px, 52vh, 340px);
         margin: 0 0.5em 1em;
         border-radius: 0.35rem;
     }
 
     .jt-content {
-        max-width: 88%;
-        padding: .8rem 1rem;
+        max-width: 92%;
+        /* Padding inferior extra para que los botones queden sobre la paginación */
+        padding: .9rem 1rem 2.7rem;
     }
 
+    /* Descripción visible en móvil (antes se ocultaba) — 2 líneas máx */
     .jt-overview {
-        display: none;
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+        margin: 0 0 .55em;
+        font-size: .78rem;
     }
 
     .jt-type-badge {
@@ -332,6 +342,18 @@
         right: .6rem;
         padding: .35em .85em;
         font-size: .68rem;
+    }
+
+    /* Botones más compactos en móvil para que no desborden */
+    .jt-btn {
+        padding: .45em 1.1em;
+        font-size: .8rem;
+    }
+
+    /* Paginación en su esquina, sin encimarse con los botones */
+    .jt-pagination {
+        bottom: .6em;
+        right: .7em;
     }
 
     .jt-prev,

--- a/build.yaml
+++ b/build.yaml
@@ -4,7 +4,7 @@
 # See: https://jellyfin.org/docs/general/server/plugins/
 name: "JellyTrend"
 guid: "d3b07384-d9a1-4e2b-8c3f-1234567890ab"
-version: "2.0.0.0"
+version: "2.0.1.0"
 targetAbi: "10.11.0.0"
 framework: "net9.0"
 overview: "Syncs TMDB trending movies & shows with the local library and provides a Netflix-style banner carousel."
@@ -17,4 +17,7 @@ owner: ".:BORNIOS:."
 artifacts:
   - "Jellyfin.Plugin.JellyTrend.dll"
 changelog: >
-  changelog
+  Correcciones:
+  - Canal Recomendados vacío en la fila de inicio (el canal ahora resuelve al usuario autenticado).
+  - Logs en nivel Debug y sin ids de usuario crudos.
+  - Banner móvil: altura del hero, sinopsis visible, botones compactos y paginación reposicionada.

--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,7 @@
     "versions": [
       {
         "version": "2.0.0.0",
-        "changelog": "Ver release notes en GitHub",
+        "changelog": "Lanzamiento 2.0.0: plantilla oficial, recomendaciones personalizadas por usuario, navegación por temporadas en los canales, banner por usuario y publicación en GitHub.",
         "targetAbi": "10.11.0.0",
         "sourceUrl": "https://github.com/BORNIOS/JellyTrend/releases/download/v2.0.0/Jellyfin.Plugin.JellyTrend-2.0.0.0.zip",
         "checksum": "501c13a3cf9078f041c7f35c3791b7fd",


### PR DESCRIPTION
## Correcciones (v2.0.1)

- **Canal Recomendados vacío en la fila de inicio**: Jellyfin refrescaba la fila con un userId vacío (Guid.Empty) y el canal no encontraba las recomendaciones del usuario. Ahora el canal resuelve al usuario autenticado a partir del token de la petición (claim Jellyfin-UserId) y envía sus recomendaciones reales.
- **Logs**: ruido reducido a nivel Debug y eliminadas las líneas con el id de usuario crudo (0000).
- **Banner móvil**: hero con altura proporcional a la pantalla, sinopsis visible (2 líneas), botones compactos y paginación reposicionada.

## Release

- Versión 2.0.1.0.
- manifest.json con changelog real (adiós a «Ver release notes en GitHub»).
- Release.yml acepta un input de changelog y lo usa en el manifest y en el body del release.