### PR TITLE
feat: v2.0.2 — contenido de canales corregido, identidad por TMDB, sync optimizado

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <Version>2.0.1.0</Version>
-    <AssemblyVersion>2.0.1.0</AssemblyVersion>
-    <FileVersion>2.0.1.0</FileVersion>
+    <Version>2.0.2.0</Version>
+    <AssemblyVersion>2.0.2.0</AssemblyVersion>
+    <FileVersion>2.0.2.0</FileVersion>
   </PropertyGroup>
 </Project>

--- a/Jellyfin.Plugin.JellyTrend/Api/RecommendationStorage.cs
+++ b/Jellyfin.Plugin.JellyTrend/Api/RecommendationStorage.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
@@ -103,5 +104,43 @@ public static class RecommendationStorage
 
         var files = Directory.GetFiles(folder, "*.json");
         return files.Length == 0 ? DateTime.MinValue : files.Max(File.GetLastWriteTimeUtc);
+    }
+
+    /// <summary>
+    /// Returns every recommended library item id across all users (de-duplicated). Used to
+    /// sync the channel shadow items of the recommendations channel on server startup.
+    /// </summary>
+    /// <returns>The unique recommended item ids.</returns>
+    public static IReadOnlyList<Guid> ReadAllItemIds()
+    {
+        var folder = Folder;
+        if (!Directory.Exists(folder))
+        {
+            return Array.Empty<Guid>();
+        }
+
+        var result = new HashSet<Guid>();
+        foreach (var file in Directory.GetFiles(folder, "*.json"))
+        {
+            try
+            {
+                var data = JsonSerializer.Deserialize<UserRecommendations>(File.ReadAllText(file));
+                if (data is null)
+                {
+                    continue;
+                }
+
+                foreach (var id in data.ItemIds)
+                {
+                    result.Add(id);
+                }
+            }
+            catch
+            {
+                // Un solo archivo corrupto no debe impedir leer el resto.
+            }
+        }
+
+        return result.ToList();
     }
 }

--- a/Jellyfin.Plugin.JellyTrend/Api/TrendingController.cs
+++ b/Jellyfin.Plugin.JellyTrend/Api/TrendingController.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Jellyfin.Data.Enums;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Plugin.JellyTrend.ScheduledTask;
+using Jellyfin.Plugin.JellyTrend.Sync;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.Entities;
@@ -78,76 +79,86 @@ public sealed class TrendingController : ControllerBase
         }
 
         var viewer = ResolveCurrentUser();
+        var showSeries = Plugin.Instance?.Configuration.EnableTrendingSeries ?? true;
 
         cache.Normalize();
 
         var dtos = cache.Items
+            .Where(entry => showSeries || entry.MediaType != TrendingMediaType.Series)
             .Select(cacheEntry => new
             {
                 Entry = cacheEntry,
-                Item = _libraryManager.GetItemById(cacheEntry.ItemId)
+                Item = TrendingItemResolver.ResolveCurrentItem(
+                    _libraryManager, cacheEntry.ItemId, cacheEntry.TmdbId, cacheEntry.MediaType == TrendingMediaType.Series)
             })
             .Where(x => x.Item is not null)
-            .Select(x =>
-            {
-                var i = x.Item!;
-                var entry = x.Entry;
-                var logoUrl = i.HasImage(ImageType.Logo, 0) ? $"/Items/{i.Id}/Images/Logo/0" : null;
-                var discUrl = i.HasImage(ImageType.Disc, 0) ? $"/Items/{i.Id}/Images/Disc/0" : null;
-                var backdropUrl = ResolveImageUrl(i, ImageType.Backdrop, entry.TmdbBackdropPath, TmdbBackdropBaseUrl, 1920, 90);
-                var primaryUrl = ResolveImageUrl(i, ImageType.Primary, entry.TmdbPosterPath, TmdbPosterBaseUrl, 400, 85);
-
-                bool? played = null;
-                long? positionTicks = null;
-                if (viewer is not null)
-                {
-                    var ud = _userDataManager.GetUserData(viewer, i);
-                    if (ud is not null)
-                    {
-                        played = ud.Played;
-                        positionTicks = ud.PlaybackPositionTicks;
-                    }
-                }
-
-                var genres = i.Genres is { Length: > 0 } g ? new List<string>(g) : null;
-                var actors = _libraryManager.GetPeople(i)
-                    .Where(p => p.Type == PersonKind.Actor)
-                    .Select(p => p.Name)
-                    .Where(n => !string.IsNullOrWhiteSpace(n))
-                    .Take(20)
-                    .ToList();
-                if (actors.Count == 0)
-                {
-                    actors = null;
-                }
-
-                return new TrendingItemDto
-                {
-                    Id = i.Id,
-                    Name = i.Name,
-                    Overview = i.Overview,
-                    Type = i.GetType().Name,
-                    TmdbId = entry.TmdbId ?? (i.ProviderIds.TryGetValue("Tmdb", out var tid) ? tid : null),
-                    BackdropImageUrl = backdropUrl,
-                    PrimaryImageUrl = primaryUrl,
-                    ProductionYear = i.ProductionYear,
-                    CommunityRating = i.CommunityRating,
-                    Genres = genres,
-                    Actors = actors,
-                    LogoImageUrl = logoUrl,
-                    DiscImageUrl = discUrl,
-                    IsPlayed = played,
-                    PlaybackPositionTicks = positionTicks,
-                    RunTimeTicks = i.RunTimeTicks,
-                    MediaStreams = null
-                };
-            });
+            .Select(x => BuildTrendingDto(x.Entry, x.Item!, viewer));
 
         // Hide titles the current user has already watched (standard Jellyfin practice).
         // In-progress items stay visible so the carousel can offer to resume them.
         var visible = dtos.Where(dto => dto.IsPlayed != true);
 
         return Ok(visible);
+    }
+
+    /// <summary>
+    /// Maps a matched trending cache entry and its library item to the carousel DTO.
+    /// </summary>
+    /// <param name="entry">The trending cache entry.</param>
+    /// <param name="item">The matched library item (not null).</param>
+    /// <param name="viewer">The authenticated user, or <c>null</c> when unavailable.</param>
+    /// <returns>The trending DTO.</returns>
+    private TrendingItemDto BuildTrendingDto(TrendingCacheEntry entry, BaseItem item, User? viewer)
+    {
+        var logoUrl = item.HasImage(ImageType.Logo, 0) ? $"/Items/{item.Id}/Images/Logo/0" : null;
+        var discUrl = item.HasImage(ImageType.Disc, 0) ? $"/Items/{item.Id}/Images/Disc/0" : null;
+        var backdropUrl = ResolveImageUrl(item, ImageType.Backdrop, entry.TmdbBackdropPath, TmdbBackdropBaseUrl, 1920, 90);
+        var primaryUrl = ResolveImageUrl(item, ImageType.Primary, entry.TmdbPosterPath, TmdbPosterBaseUrl, 400, 85);
+
+        bool? played = null;
+        long? positionTicks = null;
+        if (viewer is not null)
+        {
+            var ud = _userDataManager.GetUserData(viewer, item);
+            if (ud is not null)
+            {
+                played = ud.Played;
+                positionTicks = ud.PlaybackPositionTicks;
+            }
+        }
+
+        var genres = item.Genres is { Length: > 0 } g ? new List<string>(g) : null;
+        var actors = _libraryManager.GetPeople(item)
+            .Where(p => p.Type == PersonKind.Actor)
+            .Select(p => p.Name)
+            .Where(n => !string.IsNullOrWhiteSpace(n))
+            .Take(20)
+            .ToList();
+        if (actors.Count == 0)
+        {
+            actors = null;
+        }
+
+        return new TrendingItemDto
+        {
+            Id = item.Id,
+            Name = item.Name,
+            Overview = item.Overview,
+            Type = item.GetType().Name,
+            TmdbId = entry.TmdbId ?? (item.ProviderIds.TryGetValue("Tmdb", out var tid) ? tid : null),
+            BackdropImageUrl = backdropUrl,
+            PrimaryImageUrl = primaryUrl,
+            ProductionYear = item.ProductionYear,
+            CommunityRating = item.CommunityRating,
+            Genres = genres,
+            Actors = actors,
+            LogoImageUrl = logoUrl,
+            DiscImageUrl = discUrl,
+            IsPlayed = played,
+            PlaybackPositionTicks = positionTicks,
+            RunTimeTicks = item.RunTimeTicks,
+            MediaStreams = null
+        };
     }
 
     // ── Status ──────────────────────────────────────────────────────────────────
@@ -169,8 +180,8 @@ public sealed class TrendingController : ControllerBase
             Version = Plugin.Instance?.Version?.ToString(),
             TmdbKeyConfigured = !string.IsNullOrWhiteSpace(cfg?.TmdbApiKey),
             EnableBannerMode = cfg?.EnableBannerMode,
+            EnableTrendingSeries = cfg?.EnableTrendingSeries,
             MaxItems = cfg?.MaxItems,
-            SyncIntervalHours = cfg?.SyncIntervalHours,
             CachedItemCount = cache?.Items.Count ?? 0,
             LastUpdated = cache?.LastUpdated
         });

--- a/Jellyfin.Plugin.JellyTrend/Channel/ChannelIdentity.cs
+++ b/Jellyfin.Plugin.JellyTrend/Channel/ChannelIdentity.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Jellyfin.Plugin.JellyTrend.Configuration;
 using MediaBrowser.Controller.Library;
 
@@ -13,9 +14,48 @@ internal static class ChannelIdentity
     public static string GetConfiguredChannelName()
         => Plugin.Instance?.Configuration.ChannelName ?? PluginConfiguration.DefaultChannelName;
 
+    public static string GetConfiguredRecommendationChannelName()
+        => Plugin.Instance?.Configuration.RecommendationChannelName ?? PluginConfiguration.DefaultRecommendationChannelName;
+
+    /// <summary>
+    /// Gets the folder id of the trending channel ("JellyTrend - Trending Now").
+    /// </summary>
+    /// <param name="libraryManager">The library manager.</param>
+    /// <returns>The channel folder id.</returns>
     public static Guid GetPluginChannelFolderId(ILibraryManager libraryManager)
+        => GetChannelFolderId(libraryManager, GetConfiguredChannelName());
+
+    /// <summary>
+    /// Gets the folder id of the recommendations channel ("Recomendados").
+    /// </summary>
+    /// <param name="libraryManager">The library manager.</param>
+    /// <returns>The channel folder id.</returns>
+    public static Guid GetRecommendationChannelFolderId(ILibraryManager libraryManager)
+        => GetChannelFolderId(libraryManager, GetConfiguredRecommendationChannelName());
+
+    /// <summary>
+    /// Returns the folder ids of every JellyTrend channel (trending + recommendations).
+    /// </summary>
+    /// <param name="libraryManager">The library manager.</param>
+    /// <returns>The channel folder ids.</returns>
+    public static IEnumerable<Guid> GetAllChannelFolderIds(ILibraryManager libraryManager)
     {
-        var name = GetConfiguredChannelName();
+        yield return GetPluginChannelFolderId(libraryManager);
+        yield return GetRecommendationChannelFolderId(libraryManager);
+    }
+
+    /// <summary>
+    /// Determines whether a channel id belongs to a JellyTrend channel (trending or recommendations).
+    /// </summary>
+    /// <param name="channelId">The channel id to check.</param>
+    /// <param name="libraryManager">The library manager.</param>
+    /// <returns><c>true</c> when the channel is one of the JellyTrend channels.</returns>
+    public static bool IsJellyTrendChannelId(Guid channelId, ILibraryManager libraryManager)
+        => channelId == GetPluginChannelFolderId(libraryManager)
+            || channelId == GetRecommendationChannelFolderId(libraryManager);
+
+    private static Guid GetChannelFolderId(ILibraryManager libraryManager, string name)
+    {
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
         return libraryManager.GetNewItemId("Channel " + name, typeof(MediaBrowser.Controller.Channels.Channel));
     }

--- a/Jellyfin.Plugin.JellyTrend/Channel/ChannelItemFactory.cs
+++ b/Jellyfin.Plugin.JellyTrend/Channel/ChannelItemFactory.cs
@@ -95,6 +95,7 @@ internal static class ChannelItemFactory
         {
             Id = item.Id.ToString(),
             Name = item.Name,
+            SeriesName = item.Name,
             Overview = item.Overview,
             Type = ChannelItemType.Folder,
             FolderType = ChannelFolderType.Series,
@@ -353,7 +354,12 @@ internal static class ChannelItemFactory
                 SupportsDirectStream = true,
                 SupportsTranscoding = true,
                 RunTimeTicks = item.RunTimeTicks,
-                Container = Path.GetExtension(item.Path)?.TrimStart('.') ?? string.Empty,
+                Container = item.Container ?? Path.GetExtension(item.Path)?.TrimStart('.') ?? string.Empty,
+
+                // Las pistas de audio/subtítulos se propagan también en el fallback para que
+                // el selector de idioma del cliente (OSD) tenga siempre los MediaStreams de la
+                // película de biblioteca, igual que en la ruta principal GetStaticMediaSources.
+                MediaStreams = mediaSourceManager.GetMediaStreams(item.Id),
             }
         ];
     }

--- a/Jellyfin.Plugin.JellyTrend/Channel/RecommendedChannel.cs
+++ b/Jellyfin.Plugin.JellyTrend/Channel/RecommendedChannel.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
+using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Plugin.JellyTrend.Api;
 using Jellyfin.Plugin.JellyTrend.Configuration;
 using Jellyfin.Plugin.JellyTrend.ScheduledTask;
@@ -30,13 +31,15 @@ namespace Jellyfin.Plugin.JellyTrend.Channel;
 /// are generated weekly by RecommendationSyncTask and stored per user; each user only ever
 /// sees their own unwatched, in-progress-free recommendations (movies only).
 /// </summary>
-public sealed class RecommendedChannel : IChannel, ISupportsLatestMedia, IRequiresMediaInfoCallback
+public sealed class RecommendedChannel : IChannel, ISupportsLatestMedia, IRequiresMediaInfoCallback, IHasCacheKey
 {
     private readonly ILibraryManager _libraryManager;
     private readonly IMediaSourceManager _mediaSourceManager;
     private readonly IServerApplicationHost _appHost;
+    private readonly IUserManager _userManager;
+    private readonly IUserDataManager _userDataManager;
     private readonly IHttpContextAccessor _httpContextAccessor;
-    private readonly ILogger<RecommendedChannel> _logger;
+    private readonly ILogger _logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RecommendedChannel"/> class.
@@ -44,20 +47,27 @@ public sealed class RecommendedChannel : IChannel, ISupportsLatestMedia, IRequir
     /// <param name="libraryManager">Instance of the <see cref="ILibraryManager"/> interface.</param>
     /// <param name="mediaSourceManager">Instance of the <see cref="IMediaSourceManager"/> interface.</param>
     /// <param name="appHost">Instance of the <see cref="IServerApplicationHost"/> interface.</param>
+    /// <param name="userManager">Instance of the <see cref="IUserManager"/> interface.</param>
+    /// <param name="userDataManager">Instance of the <see cref="IUserDataManager"/> interface.</param>
     /// <param name="httpContextAccessor">Instance of the <see cref="IHttpContextAccessor"/> interface.</param>
-    /// <param name="logger">Instance of the <see cref="ILogger{RecommendedChannel}"/> interface.</param>
+    /// <param name="loggerFactory">Instance of the <see cref="ILoggerFactory"/> interface.</param>
     public RecommendedChannel(
         ILibraryManager libraryManager,
         IMediaSourceManager mediaSourceManager,
         IServerApplicationHost appHost,
+        IUserManager userManager,
+        IUserDataManager userDataManager,
         IHttpContextAccessor httpContextAccessor,
-        ILogger<RecommendedChannel> logger)
+        ILoggerFactory loggerFactory)
     {
+        JellyTrendLog.Initialize(loggerFactory);
         _libraryManager = libraryManager;
         _mediaSourceManager = mediaSourceManager;
         _appHost = appHost;
+        _userManager = userManager;
+        _userDataManager = userDataManager;
         _httpContextAccessor = httpContextAccessor;
-        _logger = logger;
+        _logger = JellyTrendLog.CreateLogger("Recommended");
     }
 
     /// <inheritdoc />
@@ -74,16 +84,18 @@ public sealed class RecommendedChannel : IChannel, ISupportsLatestMedia, IRequir
 
     /// <summary>
     /// Gets a version string that changes whenever any user's recommendations change, forcing
-    /// Jellyfin to re-fetch the channel items after each weekly sync.
+    /// Jellyfin to re-fetch the channel items after each weekly sync. El prefijo se incrementa
+    /// cuando cambian las reglas de generación de los items (filtro por usuario, imágenes
+    /// locales, sync de sombras): al desplegar una versión nueva, Jellyfin descarta las caches
+    /// de items creadas por versiones anteriores.
     /// </summary>
     public string DataVersion
     {
         get
         {
             var lastModified = RecommendationStorage.GetLastModifiedUtc();
-            return lastModified == DateTime.MinValue
-                ? "1"
-                : lastModified.Ticks.ToString(CultureInfo.InvariantCulture);
+            var ticks = lastModified == DateTime.MinValue ? 0 : lastModified.Ticks;
+            return "JT3-" + ticks.ToString(CultureInfo.InvariantCulture);
         }
     }
 
@@ -97,6 +109,23 @@ public sealed class RecommendedChannel : IChannel, ISupportsLatestMedia, IRequir
     /// <inheritdoc />
     public bool IsEnabledFor(string userId)
         => Plugin.Instance?.Configuration.EnableRecommendationRow == true;
+
+    /// <summary>
+    /// Returns a per-user cache key so Jellyfin never mixes the recommendations of
+    /// different users in the channel's on-disk cache (the home-row refresh arrives
+    /// without a user id; the real viewer is resolved from the authenticated request).
+    /// </summary>
+    /// <param name="userId">The user id passed by Jellyfin (null/empty on the home-row refresh).</param>
+    /// <returns>A cache key scoped to the real viewer.</returns>
+    public string? GetCacheKey(string? userId)
+    {
+        if (string.IsNullOrWhiteSpace(userId))
+        {
+            userId = ResolveUserId(Guid.Empty).ToString("N", CultureInfo.InvariantCulture);
+        }
+
+        return "u" + userId;
+    }
 
     /// <summary>
     /// Serves the embedded channel-recommendations.png as the channel's primary image.
@@ -199,10 +228,11 @@ public sealed class RecommendedChannel : IChannel, ISupportsLatestMedia, IRequir
         // Resolve the authenticated user from the HTTP request instead, falling back to the stored
         // recommendations only when there is no authenticated context.
         var resolved = ResolveUserId(userId);
+        var viewer = resolved == Guid.Empty ? null : SafeGetUser(resolved);
         var data = RecommendationStorage.Read(resolved) ?? RecommendationStorage.ReadAny();
         if (data is null || data.ItemIds.Count == 0)
         {
-            _logger.LogDebug("JellyTrend Recomendados: sin datos para userId={UserId} (archivo ausente o vacío).", resolved);
+            _logger.LogDebug("Sin recomendaciones para el usuario {UserId}.", resolved);
             return [];
         }
 
@@ -215,10 +245,42 @@ public sealed class RecommendedChannel : IChannel, ISupportsLatestMedia, IRequir
                 continue;
             }
 
+            // Solo contenido no reproducido previamente: se descarta lo ya visto y lo que
+            // está en progreso. Esto protege también contra el fallback ReadAny() (que en
+            // ausencia de contexto autenticado puede leer las recomendaciones de otro usuario)
+            // y contra lo que el usuario haya visto después del último sync semanal.
+            if (viewer is not null && IsAlreadyWatched(viewer, item))
+            {
+                continue;
+            }
+
+            // Se construye el ChannelItemInfo IGUAL que TrendingChannel (ExternalId = guid de
+            // librería plano, sin MediaSources embebidos): así Jellyfin materializa un item
+            // sombra VIRTUAL del canal (LocationType Remote, sin Path local), la reproducción
+            // se resuelve por el callback GetChannelItemMediaInfo y las imágenes/metadatos
+            // locales las copia TrendingShadowMetadataSync (mismo tratamiento que trending).
             result.Add(ChannelItemFactory.BuildMovieItem(_libraryManager, _appHost, item, null, null));
         }
 
-        _logger.LogDebug("JellyTrend Recomendados: leídos {Total} ids, devueltos {Count} para userId={UserId}.", data.ItemIds.Count, result.Count, resolved);
+        _logger.LogDebug("Leídos {Total} ids, devueltos {Count} para el usuario {UserId}.", data.ItemIds.Count, result.Count, resolved);
         return result;
+    }
+
+    private User? SafeGetUser(Guid userId)
+    {
+        try
+        {
+            return _userManager.GetUserById(userId);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private bool IsAlreadyWatched(User viewer, BaseItem item)
+    {
+        var userData = _userDataManager.GetUserData(viewer, item);
+        return userData is not null && (userData.Played || userData.PlaybackPositionTicks > 0);
     }
 }

--- a/Jellyfin.Plugin.JellyTrend/Channel/TrendingChannel.cs
+++ b/Jellyfin.Plugin.JellyTrend/Channel/TrendingChannel.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.JellyTrend.Configuration;
 using Jellyfin.Plugin.JellyTrend.ScheduledTask;
+using Jellyfin.Plugin.JellyTrend.Sync;
 using MediaBrowser.Controller;
 using MediaBrowser.Controller.Channels;
 using MediaBrowser.Controller.Entities;
@@ -35,6 +36,10 @@ namespace Jellyfin.Plugin.JellyTrend.Channel;
 /// </summary>
 public sealed class TrendingChannel : IChannel, IRequiresMediaInfoCallback, ISupportsLatestMedia
 {
+    // Bump cuando cambia la lógica de generación de items del canal (p. ej. resolución de librería)
+    // para forzar a Jellyfin a re-fetch y re-materializar las sombras con los ExternalId correctos.
+    private const string DataVersionSchema = "3";
+
     private readonly ILibraryManager _libraryManager;
     private readonly IMediaSourceManager _mediaSourceManager;
     private readonly IServerApplicationHost _appHost;
@@ -74,18 +79,31 @@ public sealed class TrendingChannel : IChannel, IRequiresMediaInfoCallback, ISup
     public ChannelParentalRating ParentalRating => ChannelParentalRating.GeneralAudience;
 
     /// <summary>
-    /// Gets a version string that changes whenever the trending data changes, forcing
-    /// Jellyfin to re-fetch channel items. Derived from trending.json mtime so the
-    /// channel refreshes automatically after every sync.
+    /// Gets a version string that changes whenever the trending data changes OR the plugin
+    /// configuration is saved, forcing Jellyfin to re-fetch channel items. Derived from
+    /// trending.json mtime (data changes) plus the plugin config file mtime (every save,
+    /// including the series toggle). Including the config mtime guarantees a NEW cache
+    /// version on every toggle so Jellyfin always re-fetches and purges the old series
+    /// shadow items — a plain -s0/-s1 toggle could reuse an older on-disk cache and keep
+    /// serving stale shadows on the home row.
     /// </summary>
     public string DataVersion
     {
         get
         {
             var path = Path.Combine(Plugin.Instance!.PluginFolder, "trending.json");
-            return File.Exists(path)
+            var dataTicks = File.Exists(path)
                 ? File.GetLastWriteTimeUtc(path).Ticks.ToString(CultureInfo.InvariantCulture)
                 : "1";
+
+            var configPath = Plugin.Instance?.ConfigurationFilePath;
+            var configTicks = !string.IsNullOrEmpty(configPath) && File.Exists(configPath)
+                ? File.GetLastWriteTimeUtc(configPath).Ticks.ToString(CultureInfo.InvariantCulture)
+                : "0";
+
+            var showSeries = Plugin.Instance?.Configuration.EnableTrendingSeries == true;
+            var pluginVersion = typeof(TrendingChannel).Assembly.GetName().Version?.ToString() ?? "0";
+            return $"{pluginVersion}-{DataVersionSchema}-{dataTicks}-{configTicks}-s{(showSeries ? "1" : "0")}";
         }
     }
 
@@ -190,11 +208,17 @@ public sealed class TrendingChannel : IChannel, IRequiresMediaInfoCallback, ISup
 
         cache.Normalize();
 
+        var showSeries = Plugin.Instance?.Configuration.EnableTrendingSeries ?? true;
+
         var result = new List<ChannelItemInfo>(cache.Items.Count);
 
         foreach (var cacheItem in cache.Items)
         {
-            var item = _libraryManager.GetItemById(cacheItem.ItemId);
+            // Resolución canónica: el GUID de librería es solo fast-path; si quedó stale (librería
+            // re-importada/migrada) se re-matchea por TMDB al item actual, así las series navegan
+            // a sus temporadas y las películas siguen siendo reproducibles.
+            var item = TrendingItemResolver.ResolveCurrentItem(
+                _libraryManager, cacheItem.ItemId, cacheItem.TmdbId, cacheItem.MediaType == TrendingMediaType.Series);
             if (item is null)
             {
                 continue;
@@ -202,6 +226,12 @@ public sealed class TrendingChannel : IChannel, IRequiresMediaInfoCallback, ISup
 
             if (cacheItem.MediaType == TrendingMediaType.Series)
             {
+                // Cuando el admin desactiva las series, el canal muestra solo películas.
+                if (!showSeries)
+                {
+                    continue;
+                }
+
                 // Series appear in the row as folders, always using the SERIES root
                 // metadata and artwork (a season is the only image fallback — never
                 // an episode).

--- a/Jellyfin.Plugin.JellyTrend/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.JellyTrend/Configuration/PluginConfiguration.cs
@@ -23,11 +23,6 @@ public class PluginConfiguration : BasePluginConfiguration
     public string TmdbApiKey { get; set; } = string.Empty;
 
     /// <summary>
-    /// Gets or sets the sync interval in hours.
-    /// </summary>
-    public int SyncIntervalHours { get; set; } = 24;
-
-    /// <summary>
     /// Gets or sets the maximum number of trending items to keep.
     /// </summary>
     public int MaxItems { get; set; } = 20;
@@ -36,6 +31,12 @@ public class PluginConfiguration : BasePluginConfiguration
     /// Gets or sets a value indicating whether the home banner carousel is enabled.
     /// </summary>
     public bool EnableBannerMode { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether TV series are shown in the trending channel and home
+    /// banner alongside movies. When false, only movies are shown.
+    /// </summary>
+    public bool EnableTrendingSeries { get; set; } = true;
 
     /// <summary>
     /// Gets or sets a value indicating whether the channel is visible under Channels in all clients
@@ -61,11 +62,6 @@ public class PluginConfiguration : BasePluginConfiguration
     /// Gets or sets the maximum number of recommended items generated per user.
     /// </summary>
     public int RecommendationMaxItems { get; set; } = 20;
-
-    /// <summary>
-    /// Gets or sets the interval in hours between recommendation syncs (default: weekly = 168 h).
-    /// </summary>
-    public int RecommendationSyncIntervalHours { get; set; } = 168;
 
     /// <summary>
     /// Gets or sets the BCP-47 language tag passed to TMDB (e.g. es-MX, en-US, pt-BR).

--- a/Jellyfin.Plugin.JellyTrend/Configuration/configPage.html
+++ b/Jellyfin.Plugin.JellyTrend/Configuration/configPage.html
@@ -94,17 +94,14 @@
                         <div class="fieldDescription" data-jt-html="true" data-jt="descMaxItems_html"></div>
                     </div>
 
-                    <div class="inputContainer">
-                        <label class="inputLabel inputLabelUnfocused" for="syncIntervalHours">
-                            <span data-jt="lblSyncInterval"></span>
+                    <div class="checkboxContainer checkboxContainer-withDescription">
+                        <label>
+                            <input id="enableTrendingSeries"
+                                   type="checkbox"
+                                   is="emby-checkbox" />
+                            <span data-jt="lblTrendingSeries"></span>
                         </label>
-                        <input id="syncIntervalHours"
-                               type="number"
-                               is="emby-input"
-                               min="1"
-                               max="168"
-                               value="24" />
-                        <div class="fieldDescription" data-jt-html="true" data-jt="descSyncInterval_html"></div>
+                        <div class="fieldDescription checkboxFieldDescription" data-jt-html="true" data-jt="descTrendingSeries_html"></div>
                     </div>
 
                     <div class="checkboxContainer checkboxContainer-withDescription">
@@ -151,19 +148,6 @@
                                max="100"
                                value="20" />
                         <div class="fieldDescription" data-jt-html="true" data-jt="descRecommendationMaxItems_html"></div>
-                    </div>
-
-                    <div class="inputContainer">
-                        <label class="inputLabel inputLabelUnfocused" for="recommendationSyncIntervalHours">
-                            <span data-jt="lblRecommendationSyncInterval"></span>
-                        </label>
-                        <input id="recommendationSyncIntervalHours"
-                               type="number"
-                               is="emby-input"
-                               min="1"
-                               max="720"
-                               value="168" />
-                        <div class="fieldDescription" data-jt-html="true" data-jt="descRecommendationSyncInterval_html"></div>
                     </div>
 
                 </div>
@@ -229,8 +213,8 @@
             descChannelName_html: 'Name shown under <strong>Channels</strong> in all clients.',
             lblMaxItems: 'Max trending items',
             descMaxItems_html: 'Maximum number of trending titles kept in the channel list.',
-            lblSyncInterval: 'Trending sync interval (hours)',
-            descSyncInterval_html: 'How often the Trending channel refreshes its data from TMDB (1–168 h).',
+            lblTrendingSeries: 'Show TV series in Trending',
+            descTrendingSeries_html: 'When enabled, TV series from your library appear alongside movies in the Trending channel and the home banner. Uncheck to show movies only.',
             lblBanner: 'Enable banner carousel on home',
             descBanner_html: 'When enabled, the JellyTrend script is injected into the web client home page.',
             lblRecommendationRow: 'Enable “Recomendados” row (all clients)',
@@ -240,8 +224,6 @@
             descRecommendationChannelName_html: 'Name shown under <strong>Channels</strong> in all clients.',
             lblRecommendationMaxItems: 'Max recommendations per user',
             descRecommendationMaxItems_html: 'Maximum number of recommended items generated per user.',
-            lblRecommendationSyncInterval: 'Recommendations sync interval (hours)',
-            descRecommendationSyncInterval_html: 'How often personalized recommendations are rebuilt for every user (1–720 h).',
             btnSave: 'Save',
             btnRunSync: 'Sync trending now',
             btnRunRecommendations: 'Build recommendations now',
@@ -288,8 +270,8 @@
             descChannelName_html: 'Nombre que aparece en <strong>Canales</strong> en todos los clientes.',
             lblMaxItems: 'Máximo de ítems de Trendings',
             descMaxItems_html: 'Número máximo de títulos en tendencia que se guardan en la lista del canal.',
-            lblSyncInterval: 'Intervalo de sincronización de Trendings (horas)',
-            descSyncInterval_html: 'Cada cuánto el canal de Trendings refresca sus datos desde TMDB (1–168 h).',
+            lblTrendingSeries: 'Mostrar series de TV en Trendings',
+            descTrendingSeries_html: 'Si está activado, las series de TV de tu biblioteca aparecen junto a las películas en el canal de Trendings y en el carrusel de inicio. Desactívalo para mostrar solo películas.',
             lblBanner: 'Activar carrusel en la página de inicio',
             descBanner_html: 'Si está activado, se inyecta el script de JellyTrend en la página de inicio del cliente web.',
             lblRecommendationRow: 'Activar fila de Recomendaciones (todos los clientes)',
@@ -299,8 +281,6 @@
             descRecommendationChannelName_html: 'Nombre que aparece en <strong>Canales</strong> en todos los clientes.',
             lblRecommendationMaxItems: 'Máximo de recomendaciones por usuario',
             descRecommendationMaxItems_html: 'Número máximo de recomendaciones generadas por usuario.',
-            lblRecommendationSyncInterval: 'Intervalo de sincronización de Recomendaciones (horas)',
-            descRecommendationSyncInterval_html: 'Cada cuánto se regeneran las recomendaciones personalizadas para cada usuario (1–720 h).',
             btnSave: 'Guardar',
             btnRunSync: 'Sincronizar Trendings ahora',
             btnRunRecommendations: 'Generar Recomendaciones ahora',
@@ -569,30 +549,28 @@
         getConfig()
             .then(function (cfg) {
                 var apiKey = q('tmdbApiKey');
-                var interval = q('syncIntervalHours');
                 var max = q('maxItems');
                 var banner = q('enableBannerMode');
                 var channel = q('enableChannel');
                 var tmdbLang = q('tmdbLanguage');
                 var tmdbRegion = q('tmdbRegion');
                 var channelName = q('channelName');
+                var trendingSeries = q('enableTrendingSeries');
                 var recRow = q('enableRecommendationRow');
                 var recChannelName = q('recommendationChannelName');
                 var recMax = q('recommendationMaxItems');
-                var recSync = q('recommendationSyncIntervalHours');
 
                 if (apiKey) apiKey.value = cfg.TmdbApiKey || '';
-                if (interval) interval.value = cfg.SyncIntervalHours || 24;
                 if (max) max.value = cfg.MaxItems || 20;
                 if (banner) banner.checked = cfg.EnableBannerMode !== false;
                 if (channel) channel.checked = cfg.EnableChannel !== false;
                 if (tmdbLang) tmdbLang.value = cfg.TmdbLanguage || 'es-MX';
                 if (tmdbRegion) tmdbRegion.value = cfg.TmdbRegion || 'MX';
                 if (channelName) channelName.value = cfg.ChannelName || 'JellyTrend - Trending Now';
+                if (trendingSeries) trendingSeries.checked = cfg.EnableTrendingSeries !== false;
                 if (recRow) recRow.checked = cfg.EnableRecommendationRow !== false;
                 if (recChannelName) recChannelName.value = cfg.RecommendationChannelName || 'Recomendados';
                 if (recMax) recMax.value = cfg.RecommendationMaxItems || 20;
-                if (recSync) recSync.value = cfg.RecommendationSyncIntervalHours || 168;
             })
             .catch(function (err) {
                 setStatus(t('errLoadCfg') + (err && err.message || err), true);
@@ -609,30 +587,28 @@
         getConfig()
             .then(function (cfg) {
                 var apiKey = q('tmdbApiKey');
-                var interval = q('syncIntervalHours');
                 var max = q('maxItems');
                 var banner = q('enableBannerMode');
                 var channel = q('enableChannel');
                 var tmdbLang = q('tmdbLanguage');
                 var tmdbRegion = q('tmdbRegion');
                 var channelName = q('channelName');
+                var trendingSeries = q('enableTrendingSeries');
                 var recRow = q('enableRecommendationRow');
                 var recChannelName = q('recommendationChannelName');
                 var recMax = q('recommendationMaxItems');
-                var recSync = q('recommendationSyncIntervalHours');
 
                 cfg.TmdbApiKey = apiKey ? apiKey.value : cfg.TmdbApiKey;
-                cfg.SyncIntervalHours = interval ? (Number.parseInt(interval.value, 10) || 24) : cfg.SyncIntervalHours;
                 cfg.MaxItems = max ? (Number.parseInt(max.value, 10) || 20) : cfg.MaxItems;
                 cfg.EnableBannerMode = banner ? banner.checked : cfg.EnableBannerMode;
                 cfg.EnableChannel = channel ? channel.checked : cfg.EnableChannel;
                 cfg.TmdbLanguage = tmdbLang ? tmdbLang.value.trim() : cfg.TmdbLanguage;
                 cfg.TmdbRegion = tmdbRegion ? tmdbRegion.value.trim().toUpperCase() : cfg.TmdbRegion;
                 cfg.ChannelName = channelName ? (channelName.value.trim() || 'JellyTrend - Trending Now') : cfg.ChannelName;
+                cfg.EnableTrendingSeries = trendingSeries ? trendingSeries.checked : cfg.EnableTrendingSeries;
                 cfg.EnableRecommendationRow = recRow ? recRow.checked : cfg.EnableRecommendationRow;
                 cfg.RecommendationChannelName = recChannelName ? (recChannelName.value.trim() || 'Recomendados') : cfg.RecommendationChannelName;
                 cfg.RecommendationMaxItems = recMax ? (Number.parseInt(recMax.value, 10) || 20) : cfg.RecommendationMaxItems;
-                cfg.RecommendationSyncIntervalHours = recSync ? (Number.parseInt(recSync.value, 10) || 168) : cfg.RecommendationSyncIntervalHours;
 
                 return saveConfig(cfg);
             })

--- a/Jellyfin.Plugin.JellyTrend/JellyTrendLog.cs
+++ b/Jellyfin.Plugin.JellyTrend/JellyTrendLog.cs
@@ -1,0 +1,194 @@
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using MediaBrowser.Common.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Serilog;
+using ILogger = Microsoft.Extensions.Logging.ILogger;
+
+namespace Jellyfin.Plugin.JellyTrend;
+
+/// <summary>
+/// Logger propio del plugin JellyTrend. Escribe en un archivo de log dedicado dentro del
+/// directorio de logs oficial de Jellyfin (<c>log/JellyTrend-YYYYMM.log</c>), con rotación
+/// mensual y límites de tamaño/retención para que nunca crezca sin control. Los mensajes
+/// llevan la categoría "JellyTrend" (más una sub-categoría por área) en el campo
+/// SourceContext, por lo que son fáciles de localizar y filtrar.
+/// </summary>
+internal static class JellyTrendLog
+{
+    private const int FileSizeLimitBytes = 10 * 1024 * 1024;
+    private const int RetainedFileCount = 6;
+
+    private static readonly object SyncRoot = new();
+    private static Serilog.ILogger? _serilog;
+    private static ILoggerFactory _factory = NullLoggerFactory.Instance;
+
+    /// <summary>
+    /// Initializes the plugin's dedicated file logger (idempotent). Se llama una vez al
+    /// arrancar desde <see cref="JellyTrendLogInitializer"/> con el directorio de logs real.
+    /// Si el archivo no puede crearse (permisos, bloqueo…), cae al logger del servidor para
+    /// no perder mensajes.
+    /// </summary>
+    /// <param name="applicationPaths">The server application paths (log directory).</param>
+    /// <param name="serverLoggerFactory">The server's logger factory, used as fallback.</param>
+    public static void Initialize(IApplicationPaths? applicationPaths, ILoggerFactory serverLoggerFactory)
+    {
+        lock (SyncRoot)
+        {
+            if (_factory is not NullLoggerFactory)
+            {
+                return;   // ya inicializado
+            }
+
+            var logDirectory = applicationPaths?.LogDirectoryPath;
+            if (!string.IsNullOrWhiteSpace(logDirectory))
+            {
+                try
+                {
+                    _serilog = new LoggerConfiguration()
+                        .MinimumLevel.Debug()
+                        .WriteTo.File(
+                            path: Path.Combine(logDirectory, "JellyTrend-.log"),
+                            formatProvider: CultureInfo.InvariantCulture,
+                            rollingInterval: RollingInterval.Month,
+                            fileSizeLimitBytes: FileSizeLimitBytes,
+                            rollOnFileSizeLimit: true,
+                            retainedFileCountLimit: RetainedFileCount,
+                            shared: true,
+                            outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {SourceContext}: {Message:lj}{NewLine}{Exception}")
+                        .CreateLogger();
+
+                    _factory = new JellyTrendLoggerFactory(_serilog);
+                    return;
+                }
+                catch
+                {
+                    // El archivo no pudo crearse — se usa el logger del servidor.
+                }
+            }
+
+            _factory = serverLoggerFactory ?? NullLoggerFactory.Instance;
+        }
+    }
+
+    /// <summary>
+    /// Initializes the logger using only the server factory (fallback path invoked from
+    /// constructors before the initializer runs).
+    /// </summary>
+    /// <param name="serverLoggerFactory">The server's logger factory.</param>
+    public static void Initialize(ILoggerFactory serverLoggerFactory)
+        => Initialize(null, serverLoggerFactory);
+
+    /// <summary>
+    /// Disposes the dedicated file logger, flushing pending writes.
+    /// </summary>
+    public static void Shutdown()
+    {
+        lock (SyncRoot)
+        {
+            (_serilog as IDisposable)?.Dispose();
+            _serilog = null;
+        }
+    }
+
+    /// <summary>
+    /// Creates (or reuses) a logger under the shared "JellyTrend" category.
+    /// </summary>
+    /// <param name="area">Optional sub-area, e.g. "Recommended", "Trending" or "Sync".</param>
+    /// <returns>The logger instance.</returns>
+    public static ILogger CreateLogger(string area = "")
+        => _factory.CreateLogger(string.IsNullOrEmpty(area) ? "JellyTrend" : "JellyTrend." + area);
+
+    /// <summary>
+    /// Scope de una ejecución de tarea programada: registra el inicio en Debug y emite
+    /// una única línea de resumen en Info al completar (o Error al fallar), incluyendo la
+    /// duración. Los detalles internos de cada tarea deben quedar en Debug para que el log
+    /// no se convierta en un registro gigante: por cada ejecución solo se escribe una línea
+    /// visible en nivel Info.
+    /// </summary>
+    internal sealed class TaskScope : IDisposable
+    {
+        private readonly ILogger _logger;
+        private readonly string _task;
+        private readonly Stopwatch _stopwatch;
+        private bool _done;
+
+        private TaskScope(ILogger logger, string task)
+        {
+            _logger = logger;
+            _task = task;
+            _stopwatch = Stopwatch.StartNew();
+            _logger.LogDebug("Ejecutando {Task}.", task);
+        }
+
+        /// <summary>
+        /// Starts a new task execution scope.
+        /// </summary>
+        /// <param name="logger">The plugin logger.</param>
+        /// <param name="task">The human-readable task name.</param>
+        /// <returns>The task scope to complete or dispose.</returns>
+        public static TaskScope Begin(ILogger logger, string task) => new(logger, task);
+
+        /// <summary>
+        /// Marks the task as completed, emitting a single Info line with duration and summary.
+        /// </summary>
+        /// <param name="summary">A short one-line summary of the outcome.</param>
+        public void Complete(string summary)
+        {
+            if (_done)
+            {
+                return;
+            }
+
+            _done = true;
+            _logger.LogInformation("Tarea {Task} completada en {Elapsed} ms: {Summary}.", _task, _stopwatch.ElapsedMilliseconds, summary);
+        }
+
+        /// <summary>
+        /// Marks the task as failed, emitting an Error line with the exception and duration.
+        /// </summary>
+        /// <param name="exception">The exception that caused the failure.</param>
+        /// <param name="summary">A short one-line summary of the failure.</param>
+        public void Fail(Exception exception, string summary)
+        {
+            if (_done)
+            {
+                return;
+            }
+
+            _done = true;
+            _logger.LogError(exception, "Tarea {Task} falló tras {Elapsed} ms: {Summary}.", _task, _stopwatch.ElapsedMilliseconds, summary);
+        }
+
+        /// <summary>
+        /// Marks the task as cancelled (e.g. server shutdown or manual cancel), a normal
+        /// condition that should not pollute the log.
+        /// </summary>
+        /// <param name="summary">A short one-line summary.</param>
+        public void Cancel(string summary)
+        {
+            if (_done)
+            {
+                return;
+            }
+
+            _done = true;
+            _logger.LogInformation("Tarea {Task} cancelada tras {Elapsed} ms: {Summary}.", _task, _stopwatch.ElapsedMilliseconds, summary);
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            // Si nadie llamó Complete/Fail/Cancel explícitamente, cierra la ejecución en
+            // Debug para no dejar una ejecución huérfana y evitar duplicar líneas visibles.
+            if (!_done)
+            {
+                _done = true;
+                _logger.LogDebug("Tarea {Task} finalizada tras {Elapsed} ms sin resumen.", _task, _stopwatch.ElapsedMilliseconds);
+            }
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyTrend/JellyTrendLogInitializer.cs
+++ b/Jellyfin.Plugin.JellyTrend/JellyTrendLogInitializer.cs
@@ -1,0 +1,43 @@
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Common.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.JellyTrend;
+
+/// <summary>
+/// Hosted service que inicializa el logger dedicado del plugin al arrancar Jellyfin,
+/// pasándole el directorio oficial de logs del servidor. Al apagar, cierra el archivo
+/// (flush). Se registra como <see cref="IHostedService"/> en el contenedor de DI.
+/// </summary>
+internal sealed class JellyTrendLogInitializer : IHostedService
+{
+    private readonly IApplicationPaths _applicationPaths;
+    private readonly ILoggerFactory _loggerFactory;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JellyTrendLogInitializer"/> class.
+    /// </summary>
+    /// <param name="applicationPaths">The server application paths (log directory).</param>
+    /// <param name="loggerFactory">The server's logger factory (fallback).</param>
+    public JellyTrendLogInitializer(IApplicationPaths applicationPaths, ILoggerFactory loggerFactory)
+    {
+        _applicationPaths = applicationPaths;
+        _loggerFactory = loggerFactory;
+    }
+
+    /// <inheritdoc />
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        JellyTrendLog.Initialize(_applicationPaths, _loggerFactory);
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        JellyTrendLog.Shutdown();
+        return Task.CompletedTask;
+    }
+}

--- a/Jellyfin.Plugin.JellyTrend/JellyTrendLogger.cs
+++ b/Jellyfin.Plugin.JellyTrend/JellyTrendLogger.cs
@@ -1,0 +1,65 @@
+using System;
+using Microsoft.Extensions.Logging;
+using ILogger = Microsoft.Extensions.Logging.ILogger;
+
+namespace Jellyfin.Plugin.JellyTrend;
+
+/// <summary>
+/// Writes a single <see cref="ILogger"/> message to the plugin's Serilog logger.
+/// </summary>
+internal sealed class JellyTrendLogger : ILogger
+{
+    private readonly Serilog.ILogger _serilogLogger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JellyTrendLogger"/> class.
+    /// </summary>
+    /// <param name="serilogLogger">The Serilog logger to write to.</param>
+    public JellyTrendLogger(Serilog.ILogger serilogLogger)
+    {
+        _serilogLogger = serilogLogger;
+    }
+
+    /// <inheritdoc />
+    public IDisposable? BeginScope<TState>(TState state)
+        where TState : notnull
+        => null;
+
+    /// <inheritdoc />
+    public bool IsEnabled(LogLevel logLevel)
+        => logLevel != LogLevel.None && _serilogLogger.IsEnabled(MapLevel(logLevel));
+
+    /// <inheritdoc />
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+        if (!IsEnabled(logLevel))
+        {
+            return;
+        }
+
+        var message = formatter(state, exception);
+        if (string.IsNullOrEmpty(message))
+        {
+            return;
+        }
+
+        _serilogLogger.Write(MapLevel(logLevel), exception, "{Message}", message);
+    }
+
+    private static Serilog.Events.LogEventLevel MapLevel(LogLevel level)
+        => level switch
+        {
+            LogLevel.Trace => Serilog.Events.LogEventLevel.Verbose,
+            LogLevel.Debug => Serilog.Events.LogEventLevel.Debug,
+            LogLevel.Information => Serilog.Events.LogEventLevel.Information,
+            LogLevel.Warning => Serilog.Events.LogEventLevel.Warning,
+            LogLevel.Error => Serilog.Events.LogEventLevel.Error,
+            LogLevel.Critical => Serilog.Events.LogEventLevel.Fatal,
+            _ => Serilog.Events.LogEventLevel.Debug
+        };
+}

--- a/Jellyfin.Plugin.JellyTrend/JellyTrendLoggerFactory.cs
+++ b/Jellyfin.Plugin.JellyTrend/JellyTrendLoggerFactory.cs
@@ -1,0 +1,36 @@
+using System;
+using Microsoft.Extensions.Logging;
+using ILogger = Microsoft.Extensions.Logging.ILogger;
+
+namespace Jellyfin.Plugin.JellyTrend;
+
+/// <summary>
+/// Adapta la API <c>Microsoft.Extensions.Logging.ILoggerFactory</c> al logger de Serilog
+/// del plugin, de modo que el código existente que usa <see cref="ILogger"/> siga
+/// funcionando sin cambios y termine escribiendo en el archivo de log dedicado.
+/// </summary>
+internal sealed class JellyTrendLoggerFactory : ILoggerFactory
+{
+    private readonly Serilog.ILogger _serilogLogger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JellyTrendLoggerFactory"/> class.
+    /// </summary>
+    /// <param name="serilogLogger">The Serilog logger to write to.</param>
+    public JellyTrendLoggerFactory(Serilog.ILogger serilogLogger)
+    {
+        _serilogLogger = serilogLogger;
+    }
+
+    /// <inheritdoc />
+    public ILogger CreateLogger(string categoryName)
+        => new JellyTrendLogger(_serilogLogger.ForContext(Serilog.Core.Constants.SourceContextPropertyName, categoryName));
+
+    /// <inheritdoc />
+    public void AddProvider(ILoggerProvider provider)
+    {
+    }
+
+    /// <inheritdoc />
+    public void Dispose() => (_serilogLogger as IDisposable)?.Dispose();
+}

--- a/Jellyfin.Plugin.JellyTrend/Jellyfin.Plugin.JellyTrend.csproj
+++ b/Jellyfin.Plugin.JellyTrend/Jellyfin.Plugin.JellyTrend.csproj
@@ -32,6 +32,17 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!--
+      Serilog is the logging library Jellyfin itself uses. The plugin builds its own
+      logger with a file sink so it writes to a dedicated per-month log file
+      (log/JellyTrend-YYYYMM.log) inside the server's official log directory.
+      Versions match the local server runtime (Serilog 4.2.0).
+    -->
+    <PackageReference Include="Serilog" Version="4.2.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <!-- Code analysis packages (build-time only, never shipped with the plugin) -->
     <PackageReference Include="SerilogAnalyzer" Version="0.15.0" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="All" />

--- a/Jellyfin.Plugin.JellyTrend/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.JellyTrend/PluginServiceRegistrator.cs
@@ -43,5 +43,10 @@ public sealed class PluginServiceRegistrator : IPluginServiceRegistrator
         // JellyTrendStartupFilter wraps the app builder to prepend ScriptInjectionMiddleware.
         serviceCollection.AddTransient<IStartupFilter, JellyTrendStartupFilter>();
         serviceCollection.AddTransient<ScriptInjectionMiddleware>();
+
+        // Initializes the plugin's dedicated file logger (log/JellyTrend-YYYYMM.log)
+        // when the server starts, and flushes it on shutdown.
+        serviceCollection.AddSingleton<JellyTrendLogInitializer>();
+        serviceCollection.AddSingleton<IHostedService>(sp => sp.GetRequiredService<JellyTrendLogInitializer>());
     }
 }

--- a/Jellyfin.Plugin.JellyTrend/ScheduledTask/RecommendationSyncTask.cs
+++ b/Jellyfin.Plugin.JellyTrend/ScheduledTask/RecommendationSyncTask.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Plugin.JellyTrend.Api;
+using Jellyfin.Plugin.JellyTrend.Sync;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.Tasks;
 using Microsoft.Extensions.Logging;
@@ -22,7 +23,7 @@ public sealed class RecommendationSyncTask : IScheduledTask
     private readonly ILibraryManager _libraryManager;
     private readonly IUserManager _userManager;
     private readonly IUserDataManager _userDataManager;
-    private readonly ILogger<RecommendationSyncTask> _logger;
+    private readonly ILogger _logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RecommendationSyncTask"/> class.
@@ -30,17 +31,18 @@ public sealed class RecommendationSyncTask : IScheduledTask
     /// <param name="libraryManager">Instance of the <see cref="ILibraryManager"/> interface.</param>
     /// <param name="userManager">Instance of the <see cref="IUserManager"/> interface.</param>
     /// <param name="userDataManager">Instance of the <see cref="IUserDataManager"/> interface.</param>
-    /// <param name="logger">Instance of the <see cref="ILogger{RecommendationSyncTask}"/> interface.</param>
+    /// <param name="loggerFactory">Instance of the <see cref="ILoggerFactory"/> interface.</param>
     public RecommendationSyncTask(
         ILibraryManager libraryManager,
         IUserManager userManager,
         IUserDataManager userDataManager,
-        ILogger<RecommendationSyncTask> logger)
+        ILoggerFactory loggerFactory)
     {
+        JellyTrendLog.Initialize(loggerFactory);
         _libraryManager = libraryManager;
         _userManager = userManager;
         _userDataManager = userDataManager;
-        _logger = logger;
+        _logger = JellyTrendLog.CreateLogger("Recommendations");
     }
 
     /// <inheritdoc />
@@ -56,68 +58,99 @@ public sealed class RecommendationSyncTask : IScheduledTask
     public string Key => "JellyTrendRecommendations";
 
     /// <inheritdoc />
-    public Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
+    public async Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
     {
         var config = Plugin.Instance!.Configuration;
         if (!config.EnableRecommendationRow)
         {
-            _logger.LogInformation("JellyTrend: fila de recomendaciones desactivada — tarea omitida.");
-            return Task.CompletedTask;
+            _logger.LogInformation("Fila de recomendaciones desactivada — tarea omitida.");
+            return;
         }
 
-        var trendingItemIds = LoadTrendingItemIds();
         var users = _userManager.GetUsers().ToList();
         if (users.Count == 0)
         {
-            _logger.LogInformation("JellyTrend: sin usuarios — tarea de recomendaciones omitida.");
-            return Task.CompletedTask;
+            _logger.LogInformation("Sin usuarios — tarea de recomendaciones omitida.");
+            return;
         }
 
-        progress.Report(0);
-        for (var i = 0; i < users.Count; i++)
+        using var scope = JellyTrendLog.TaskScope.Begin(_logger, "Recomendaciones semanales");
+        try
         {
-            cancellationToken.ThrowIfCancellationRequested();
-            var user = users[i];
+            var trendingItemIds = LoadTrendingItemIds();
+            progress.Report(0);
 
-            try
+            var allRecommendedIds = new List<Guid>();
+            var generated = 0;
+            var failed = 0;
+            for (var i = 0; i < users.Count; i++)
             {
-                var ids = RecommendationEngine.BuildRecommendations(
-                    _libraryManager,
-                    _userDataManager,
-                    user,
-                    trendingItemIds,
-                    config.RecommendationMaxItems);
+                cancellationToken.ThrowIfCancellationRequested();
+                var user = users[i];
 
-                RecommendationStorage.Write(user.Id, new UserRecommendations
+                try
                 {
-                    ItemIds = ids,
-                    UpdatedAt = DateTime.UtcNow
-                });
+                    var ids = RecommendationEngine.BuildRecommendations(
+                        _libraryManager,
+                        _userDataManager,
+                        user,
+                        trendingItemIds,
+                        config.RecommendationMaxItems);
 
-                _logger.LogInformation("JellyTrend: {Count} recomendaciones para '{User}'.", ids.Count, user.Username);
+                    RecommendationStorage.Write(user.Id, new UserRecommendations
+                    {
+                        ItemIds = ids,
+                        UpdatedAt = DateTime.UtcNow
+                    });
+
+                    allRecommendedIds.AddRange(ids);
+                    generated++;
+                    _logger.LogDebug("{Count} recomendaciones para '{User}'.", ids.Count, user.Username);
+                }
+                catch (Exception ex)
+                {
+                    failed++;
+                    _logger.LogWarning(ex, "Fallo al generar recomendaciones para '{User}'.", user.Username);
+                }
+
+                progress.Report((i + 1) * 100d / users.Count);
             }
-            catch (Exception ex)
+
+            // Copiar metadatos, reparto e imágenes LOCALES a los items sombra del canal de
+            // Recomendados (mismo tratamiento que el canal de tendencias): así las tarjetas
+            // muestran el poster local y el detalle no queda como un item sombra pobre.
+            if (allRecommendedIds.Count > 0)
             {
-                _logger.LogWarning(ex, "JellyTrend: fallo al generar recomendaciones para '{User}'.", user.Username);
+                await TrendingShadowMetadataSync
+                    .SyncAllAsync(_libraryManager, allRecommendedIds, _logger, cancellationToken)
+                    .ConfigureAwait(false);
             }
 
-            progress.Report((i + 1) * 100d / users.Count);
+            scope.Complete($"{generated} usuarios con recomendaciones, {failed} con errores de {users.Count}");
         }
-
-        _logger.LogInformation("JellyTrend: recomendaciones completadas para {Count} usuarios.", users.Count);
-        return Task.CompletedTask;
+        catch (OperationCanceledException)
+        {
+            scope.Cancel("cancelada (usuario o apagado del servidor)");
+            throw;
+        }
+        catch (Exception ex)
+        {
+            scope.Fail(ex, "error al procesar recomendaciones");
+            throw;
+        }
     }
 
     /// <inheritdoc />
     public IEnumerable<TaskTriggerInfo> GetDefaultTriggers()
     {
-        var intervalHours = Plugin.Instance?.Configuration.RecommendationSyncIntervalHours ?? 168;
+        // El horario real se gestiona desde Dashboard → Tareas; esto es solo el intervalo
+        // por defecto (semanal = 168 h) para la primera instalación.
         return
         [
             new TaskTriggerInfo
             {
                 Type = TaskTriggerInfoType.IntervalTrigger,
-                IntervalTicks = TimeSpan.FromHours(intervalHours).Ticks
+                IntervalTicks = TimeSpan.FromHours(168).Ticks
             }
         ];
     }

--- a/Jellyfin.Plugin.JellyTrend/ScheduledTask/TrendingSyncTask.cs
+++ b/Jellyfin.Plugin.JellyTrend/ScheduledTask/TrendingSyncTask.cs
@@ -10,6 +10,8 @@ using Jellyfin.Data.Enums;
 using Jellyfin.Plugin.JellyTrend.ExternalAPI;
 using Jellyfin.Plugin.JellyTrend.Sync;
 using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Entities;
@@ -31,7 +33,7 @@ public sealed class TrendingSyncTask : IScheduledTask
     private readonly ILibraryManager _libraryManager;
     private readonly IProviderManager _providerManager;
     private readonly TmdbClient _tmdbClient;
-    private readonly ILogger<TrendingSyncTask> _logger;
+    private readonly ILogger _logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TrendingSyncTask"/> class.
@@ -39,17 +41,18 @@ public sealed class TrendingSyncTask : IScheduledTask
     /// <param name="libraryManager">Instance of the <see cref="ILibraryManager"/> interface.</param>
     /// <param name="providerManager">Instance of the <see cref="IProviderManager"/> interface.</param>
     /// <param name="tmdbClient">The TMDB client.</param>
-    /// <param name="logger">Instance of the <see cref="ILogger{TrendingSyncTask}"/> interface.</param>
+    /// <param name="loggerFactory">Instance of the <see cref="ILoggerFactory"/> interface.</param>
     public TrendingSyncTask(
         ILibraryManager libraryManager,
         IProviderManager providerManager,
         TmdbClient tmdbClient,
-        ILogger<TrendingSyncTask> logger)
+        ILoggerFactory loggerFactory)
     {
+        JellyTrendLog.Initialize(loggerFactory);
         _libraryManager = libraryManager;
         _providerManager = providerManager;
         _tmdbClient = tmdbClient;
-        _logger = logger;
+        _logger = JellyTrendLog.CreateLogger("Sync");
     }
 
     /// <inheritdoc />
@@ -71,93 +74,103 @@ public sealed class TrendingSyncTask : IScheduledTask
 
         if (string.IsNullOrWhiteSpace(config.TmdbApiKey))
         {
-            _logger.LogWarning("JellyTrend: TMDB API key no configurada — sync omitido.");
+            _logger.LogWarning("TMDB API key no configurada — sync omitido.");
             return;
         }
 
-        progress.Report(0);
-        _logger.LogDebug("JellyTrend: Iniciando sync (máximo {Max} títulos por tipo desde TMDB).", config.MaxItems);
-
-        // ── 1. Obtener IDs trending de TMDB (semanal, películas y series) ──────
-        var trendingMovies = await _tmdbClient
-            .GetTrendingMoviesAsync(config.TmdbApiKey, config.MaxItems, config.TmdbLanguage, config.TmdbRegion, cancellationToken)
-            .ConfigureAwait(false);
-        var trendingShows = await _tmdbClient
-            .GetTrendingTvAsync(config.TmdbApiKey, config.MaxItems, config.TmdbLanguage, config.TmdbRegion, cancellationToken)
-            .ConfigureAwait(false);
-        progress.Report(30);
-
-        // ── 2. Emparejar con la librería local ─────────────────────────────────
-        var matchedItems = new List<TrendingCacheEntry>();
-
-        foreach (var tmdbItem in trendingMovies)
+        using var scope = JellyTrendLog.TaskScope.Begin(_logger, "Sync de tendencias TMDB");
+        try
         {
-            var tmdbId = tmdbItem.Id.ToString(CultureInfo.InvariantCulture);
-            var match = FindByTmdbId(tmdbId, BaseItemKind.Movie);
-            if (match is not null)
+            progress.Report(0);
+            _logger.LogDebug("Máximo {Max} títulos por tipo desde TMDB.", config.MaxItems);
+
+            // ── 1. Obtener IDs trending de TMDB (semanal, películas y series) ──
+            var trendingMovies = await _tmdbClient
+                .GetTrendingMoviesAsync(config.TmdbApiKey, config.MaxItems, config.TmdbLanguage, config.TmdbRegion, cancellationToken)
+                .ConfigureAwait(false);
+            var trendingShows = await _tmdbClient
+                .GetTrendingTvAsync(config.TmdbApiKey, config.MaxItems, config.TmdbLanguage, config.TmdbRegion, cancellationToken)
+                .ConfigureAwait(false);
+            progress.Report(30);
+
+            // ── 2. Emparejar con la librería local ─────────────────────────────
+            var matchedItems = new List<TrendingCacheEntry>();
+
+            foreach (var tmdbItem in trendingMovies)
             {
-                matchedItems.Add(new TrendingCacheEntry
+                var tmdbId = tmdbItem.Id.ToString(CultureInfo.InvariantCulture);
+                var match = FindByTmdbId(tmdbId, BaseItemKind.Movie);
+                if (match is not null)
                 {
-                    ItemId = match.Id,
-                    MediaType = TrendingMediaType.Movie,
-                    TmdbId = tmdbId,
-                    TmdbBackdropPath = tmdbItem.BackdropPath,
-                    TmdbPosterPath = tmdbItem.PosterPath
-                });
-                _logger.LogDebug("JellyTrend: Match '{Name}' (TMDB {Id})", match.Name, tmdbId);
+                    matchedItems.Add(new TrendingCacheEntry
+                    {
+                        ItemId = match.Id,
+                        MediaType = TrendingMediaType.Movie,
+                        TmdbId = tmdbId,
+                        TmdbBackdropPath = tmdbItem.BackdropPath,
+                        TmdbPosterPath = tmdbItem.PosterPath
+                    });
+                    _logger.LogDebug("Match '{Name}' (TMDB {Id})", match.Name, tmdbId);
+                }
             }
-        }
 
-        foreach (var tmdbItem in trendingShows)
-        {
-            var tmdbId = tmdbItem.Id.ToString(CultureInfo.InvariantCulture);
-            var match = FindByTmdbId(tmdbId, BaseItemKind.Series);
-            if (match is not null)
+            foreach (var tmdbItem in trendingShows)
             {
-                matchedItems.Add(new TrendingCacheEntry
+                var tmdbId = tmdbItem.Id.ToString(CultureInfo.InvariantCulture);
+                var match = FindByTmdbId(tmdbId, BaseItemKind.Series);
+                if (match is not null)
                 {
-                    ItemId = match.Id,
-                    MediaType = TrendingMediaType.Series,
-                    TmdbId = tmdbId,
-                    TmdbBackdropPath = tmdbItem.BackdropPath,
-                    TmdbPosterPath = tmdbItem.PosterPath
-                });
-                _logger.LogDebug("JellyTrend: Match serie '{Name}' (TMDB {Id})", match.Name, tmdbId);
+                    matchedItems.Add(new TrendingCacheEntry
+                    {
+                        ItemId = match.Id,
+                        MediaType = TrendingMediaType.Series,
+                        TmdbId = tmdbId,
+                        TmdbBackdropPath = tmdbItem.BackdropPath,
+                        TmdbPosterPath = tmdbItem.PosterPath
+                    });
+                    _logger.LogDebug("Match serie '{Name}' (TMDB {Id})", match.Name, tmdbId);
+                }
             }
+
+            progress.Report(70);
+
+            var movieCount = matchedItems.Count(static item => item.MediaType == TrendingMediaType.Movie);
+            var seriesCount = matchedItems.Count(static item => item.MediaType == TrendingMediaType.Series);
+
+            // ── 3. Completar imágenes locales faltantes (patrón oficial Jellyfin) ─
+            foreach (var matched in matchedItems)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await EnsureLocalImagesAsync(matched, cancellationToken).ConfigureAwait(false);
+            }
+
+            progress.Report(85);
+
+            // ── 4. Guardar caché JSON ───────────────────────────────────────────
+            var cache = new TrendingCache { Items = matchedItems, LastUpdated = DateTime.UtcNow };
+            var dataPath = Path.Combine(Plugin.Instance.PluginFolder, "trending.json");
+            await File.WriteAllTextAsync(
+                dataPath,
+                JsonSerializer.Serialize(cache, CacheJsonOptions),
+                cancellationToken).ConfigureAwait(false);
+
+            await TrendingShadowMetadataSync
+                .SyncAllAsync(_libraryManager, matchedItems, _logger, cancellationToken)
+                .ConfigureAwait(false);
+
+            progress.Report(100);
+            scope.Complete($"{movieCount} películas y {seriesCount} series emparejadas de {trendingMovies.Count}+{trendingShows.Count} de TMDB");
         }
-
-        progress.Report(70);
-
-        _logger.LogInformation(
-            "JellyTrend: {MatchedMovies} películas y {MatchedSeries} series emparejadas de {TotalMovies}+{TotalSeries} en TMDB trending semanal.",
-            matchedItems.Count(static item => item.MediaType == TrendingMediaType.Movie),
-            matchedItems.Count(static item => item.MediaType == TrendingMediaType.Series),
-            trendingMovies.Count,
-            trendingShows.Count);
-
-        // ── 3. Completar imágenes locales faltantes (patrón oficial Jellyfin) ─
-        foreach (var matched in matchedItems)
+        catch (OperationCanceledException)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-            await EnsureLocalImagesAsync(matched, cancellationToken).ConfigureAwait(false);
+            scope.Cancel("cancelada (usuario o apagado del servidor)");
+            throw;
         }
-
-        progress.Report(85);
-
-        // ── 3. Guardar caché JSON ───────────────────────────────────────────────
-        var cache = new TrendingCache { Items = matchedItems, LastUpdated = DateTime.UtcNow };
-        var dataPath = Path.Combine(Plugin.Instance!.PluginFolder, "trending.json");
-        await File.WriteAllTextAsync(
-            dataPath,
-            JsonSerializer.Serialize(cache, CacheJsonOptions),
-            cancellationToken).ConfigureAwait(false);
-
-        await TrendingShadowMetadataSync
-            .SyncAllAsync(_libraryManager, matchedItems.Select(static item => item.ItemId).ToList(), _logger, cancellationToken)
-            .ConfigureAwait(false);
-
-        progress.Report(100);
-        _logger.LogInformation("JellyTrend: Sync completo — {Count} títulos en caché.", matchedItems.Count);
+        catch (Exception ex)
+        {
+            scope.Fail(ex, "error al sincronizar tendencias");
+            throw;
+        }
     }
 
     private async Task EnsureLocalImagesAsync(TrendingCacheEntry cacheEntry, CancellationToken cancellationToken)
@@ -191,7 +204,7 @@ public sealed class TrendingSyncTask : IScheduledTask
         {
             _logger.LogDebug(
                 ex,
-                "JellyTrend: no se pudieron completar imágenes para '{Name}' ({ItemId}).",
+                "No se pudieron completar imágenes para '{Name}' ({ItemId}).",
                 item.Name,
                 item.Id);
         }
@@ -210,22 +223,42 @@ public sealed class TrendingSyncTask : IScheduledTask
             HasAnyProviderId = new Dictionary<string, string> { ["Tmdb"] = tmdbId },
             IncludeItemTypes = [kind],
             IsVirtualItem = false,
-            Limit = 1
+            Limit = 10
         });
 
-        return items.Count > 0 ? items[0] : null;
+        foreach (var item in items)
+        {
+            // Excluir sombras de canal (copian el Tmdb provider id y no se marcan como virtuales)
+            // y validar que el tipo coincida: el provider puede ignorar IncludeItemTypes en algunas
+            // combinaciones de filtros.
+            if (item.ChannelId == Guid.Empty && MatchesKind(item, kind))
+            {
+                return item;
+            }
+        }
+
+        return null;
     }
+
+    private static bool MatchesKind(BaseItem item, BaseItemKind kind)
+        => kind switch
+        {
+            BaseItemKind.Movie => item is Movie,
+            BaseItemKind.Series => item is Series,
+            _ => true
+        };
 
     /// <inheritdoc />
     public IEnumerable<TaskTriggerInfo> GetDefaultTriggers()
     {
-        var intervalHours = Plugin.Instance?.Configuration.SyncIntervalHours ?? 24;
+        // El horario real se gestiona desde Dashboard → Tareas; esto es solo el intervalo
+        // por defecto (24 h) para la primera instalación.
         return
         [
             new TaskTriggerInfo
             {
                 Type = TaskTriggerInfoType.IntervalTrigger,
-                IntervalTicks = TimeSpan.FromHours(intervalHours).Ticks
+                IntervalTicks = TimeSpan.FromHours(24).Ticks
             }
         ];
     }

--- a/Jellyfin.Plugin.JellyTrend/Sync/TrendingItemResolver.cs
+++ b/Jellyfin.Plugin.JellyTrend/Sync/TrendingItemResolver.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using Jellyfin.Data.Enums;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Entities.TV;
+using MediaBrowser.Controller.Library;
+
+namespace Jellyfin.Plugin.JellyTrend.Sync;
+
+/// <summary>
+/// Resolves the CURRENT library item behind a trending entry.
+///
+/// <para>
+/// DESIGN: a library item GUID is NOT a stable identifier in Jellyfin. A rescan, a re-import, a
+/// path change or a database migration (e.g. SQLite → Postgres) can replace an item with a brand
+/// new GUID while keeping the same TMDB provider id. Caches that persist only the library GUID
+/// (like <c>trending.json</c>) therefore end up pointing at dead items after the library changes,
+/// breaking folder navigation (no seasons) and local image copying.
+/// </para>
+///
+/// <para>
+/// The TMDB id is the canonical, stable key. The stored library GUID is used as a fast path only:
+/// when it still resolves it is returned directly; otherwise the current library item is re-matched
+/// by its TMDB provider id. This makes the plugin resilient to library re-imports without forcing a
+/// resync.
+/// </para>
+/// </summary>
+public static class TrendingItemResolver
+{
+    /// <summary>
+    /// Returns the library item that currently represents the given trending entry, re-matching by
+    /// TMDB when the stored id is stale.
+    /// </summary>
+    /// <param name="libraryManager">The library manager.</param>
+    /// <param name="itemId">The library id stored in the cache (may be stale).</param>
+    /// <param name="tmdbId">The canonical TMDB id, or <c>null</c> when unknown.</param>
+    /// <param name="isSeries">Whether the entry is a series (<see langword="true"/>) or a movie.</param>
+    /// <returns>The current library item, or <c>null</c> when it cannot be resolved.</returns>
+    public static BaseItem? ResolveCurrentItem(
+        ILibraryManager libraryManager,
+        Guid itemId,
+        string? tmdbId,
+        bool isSeries)
+    {
+        var kind = isSeries ? BaseItemKind.Series : BaseItemKind.Movie;
+
+        var byId = libraryManager.GetItemById(itemId);
+        if (byId is not null && byId.ChannelId == Guid.Empty && MatchesKind(byId, isSeries))
+        {
+            return byId;
+        }
+
+        if (string.IsNullOrWhiteSpace(tmdbId))
+        {
+            return null;
+        }
+
+        // Los items sombra de canal copian el Tmdb provider id de la librería y NO se marcan como
+        // virtuales, así que aparecen en esta búsqueda. Solo un item real de librería (ChannelId
+        // vacío) del tipo esperado es un match válido; de lo contrario la navegación a temporadas
+        // y la copia de imágenes fallarían contra la sombra en lugar de la serie real.
+        var matches = libraryManager.GetItemList(new InternalItemsQuery
+        {
+            HasAnyProviderId = new Dictionary<string, string> { ["Tmdb"] = tmdbId },
+            IncludeItemTypes = [kind],
+            IsVirtualItem = false,
+            Limit = 10
+        });
+
+        foreach (var match in matches)
+        {
+            if (match.ChannelId == Guid.Empty && MatchesKind(match, isSeries))
+            {
+                return match;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool MatchesKind(BaseItem item, bool isSeries)
+        => isSeries ? item is Series : item is Movie;
+}

--- a/Jellyfin.Plugin.JellyTrend/Sync/TrendingLibraryLinkService.cs
+++ b/Jellyfin.Plugin.JellyTrend/Sync/TrendingLibraryLinkService.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Plugin.JellyTrend;
+using Jellyfin.Plugin.JellyTrend.Api;
 using Jellyfin.Plugin.JellyTrend.ScheduledTask;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Events;
@@ -72,21 +73,7 @@ public sealed class TrendingLibraryLinkService
                 try
                 {
                     await Task.Delay(TimeSpan.FromSeconds(40), CancellationToken.None).ConfigureAwait(false);
-                    var cache = ReadTrendingCache();
-                    if (cache is null)
-                    {
-                        return;
-                    }
-
-                    cache.Normalize();
-                    if (cache.Items.Count == 0)
-                    {
-                        return;
-                    }
-
-                    await TrendingShadowMetadataSync
-                        .SyncAllAsync(_libraryManager, cache.Items.Select(static item => item.ItemId).ToList(), _logger, CancellationToken.None)
-                        .ConfigureAwait(false);
+                    await RunStartupSyncAsync().ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {
@@ -96,6 +83,32 @@ public sealed class TrendingLibraryLinkService
             CancellationToken.None);
 
         return Task.CompletedTask;
+    }
+
+    private async Task RunStartupSyncAsync()
+    {
+        // Sombra de TENDENCIAS: copiar metadatos/reparto/imágenes locales.
+        var cache = ReadTrendingCache();
+        if (cache is not null)
+        {
+            cache.Normalize();
+            if (cache.Items.Count > 0)
+            {
+                await TrendingShadowMetadataSync
+                    .SyncAllAsync(_libraryManager, cache.Items, _logger, CancellationToken.None)
+                    .ConfigureAwait(false);
+            }
+        }
+
+        // Sombra de RECOMENDACIONES: mismo tratamiento para que las tarjetas
+        // muestren el poster local y el estado visto quede sincronizado.
+        var recommendedIds = RecommendationStorage.ReadAllItemIds();
+        if (recommendedIds.Count > 0)
+        {
+            await TrendingShadowMetadataSync
+                .SyncAllAsync(_libraryManager, recommendedIds, _logger, CancellationToken.None)
+                .ConfigureAwait(false);
+        }
     }
 
     /// <summary>
@@ -195,16 +208,13 @@ public sealed class TrendingLibraryLinkService
                 }
                 else if (IsTrendingLibraryMovie(playedItem))
                 {
-                    var shadow = TrendingShadowMetadataSync.FindShadowMovie(_libraryManager, playedItem.Id);
-                    if (shadow is null)
+                    foreach (var shadow in FindShadows(playedItem.Id))
                     {
-                        continue;
+                        var copy = CloneForTarget(user, sourceData, shadow);
+                        ApplyPlaybackHints(copy, playedItem, playbackPositionTicks, playedToCompletion);
+                        copy.PlaybackPositionTicks = 0;
+                        SaveMirrored(user, shadow, copy);
                     }
-
-                    var copy = CloneForTarget(user, sourceData, shadow);
-                    ApplyPlaybackHints(copy, playedItem, playbackPositionTicks, playedToCompletion);
-                    copy.PlaybackPositionTicks = 0;
-                    SaveMirrored(user, shadow, copy);
                 }
             }
             catch (Exception ex)
@@ -243,15 +253,12 @@ public sealed class TrendingLibraryLinkService
         }
         else if (IsTrendingLibraryMovie(args.Item))
         {
-            var shadow = TrendingShadowMetadataSync.FindShadowMovie(_libraryManager, args.Item.Id);
-            if (shadow is null)
+            foreach (var shadow in FindShadows(args.Item.Id))
             {
-                return;
+                var data = CloneForTarget(user, args.UserData, shadow);
+                data.PlaybackPositionTicks = 0;
+                SaveMirrored(user, shadow, data);
             }
-
-            var data = CloneForTarget(user, args.UserData, shadow);
-            data.PlaybackPositionTicks = 0;
-            SaveMirrored(user, shadow, data);
         }
     }
 
@@ -342,11 +349,22 @@ public sealed class TrendingLibraryLinkService
             return false;
         }
 
-        var folderId = ChannelIdentity.GetPluginChannelFolderId(_libraryManager);
-        return item.ChannelId == folderId;
+        return ChannelIdentity.IsJellyTrendChannelId(item.ChannelId, _libraryManager);
     }
 
-    private bool IsTrendingLibraryMovie(BaseItem item)
+    private IEnumerable<BaseItem> FindShadows(Guid libraryMovieId)
+    {
+        foreach (var channelFolderId in ChannelIdentity.GetAllChannelFolderIds(_libraryManager))
+        {
+            var shadow = TrendingShadowMetadataSync.FindShadowMovie(_libraryManager, channelFolderId, libraryMovieId);
+            if (shadow is not null)
+            {
+                yield return shadow;
+            }
+        }
+    }
+
+    private static bool IsTrendingLibraryMovie(BaseItem item)
     {
         if (item.ChannelId != Guid.Empty || string.IsNullOrEmpty(item.Path))
         {

--- a/Jellyfin.Plugin.JellyTrend/Sync/TrendingShadowMetadataSync.cs
+++ b/Jellyfin.Plugin.JellyTrend/Sync/TrendingShadowMetadataSync.cs
@@ -6,7 +6,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Data.Enums;
 using Jellyfin.Plugin.JellyTrend;
+using Jellyfin.Plugin.JellyTrend.ScheduledTask;
 using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.Entities;
 using Microsoft.Extensions.Logging;
@@ -16,27 +18,92 @@ namespace Jellyfin.Plugin.JellyTrend.Sync;
 /// <summary>
 /// Jellyfin solo aplica <c>UpdatePeopleAsync</c> al crear ítems sombra del canal; los ya existentes
 /// no reciben reparto ni metadatos desde <see cref="MediaBrowser.Controller.Channels.ChannelItemInfo"/>.
-/// Copiamos metadatos clave y el reparto desde la película de biblioteca hacia el sombra.
+/// Copiamos metadatos clave, el reparto y las imágenes LOCALES desde la película de biblioteca hacia el
+/// sombra, en cualquiera de los canales de JellyTrend (tendencias y recomendaciones).
 /// </summary>
 public static class TrendingShadowMetadataSync
 {
     /// <summary>
-    /// Copies key metadata and cast from each library movie to its channel shadow item.
+    /// Copies key metadata, cast and local images from each trending cache entry to its channel
+    /// shadow item, for every JellyTrend channel (trending and recommendations) where the shadow
+    /// exists. Entries whose stored id is stale are re-matched by TMDB first. Also removes any
+    /// episode shadow items so the trending row never shows episodes.
     /// </summary>
     /// <param name="libraryManager">Instance of the <see cref="ILibraryManager"/> interface.</param>
-    /// <param name="libraryMovieIds">The library movie ids to sync.</param>
+    /// <param name="cacheEntries">The trending cache entries (movies and series) to sync.</param>
     /// <param name="logger">The logger.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     public static async Task SyncAllAsync(
         ILibraryManager libraryManager,
-        IReadOnlyList<Guid> libraryMovieIds,
+        IReadOnlyList<TrendingCacheEntry> cacheEntries,
         ILogger logger,
         CancellationToken cancellationToken)
     {
-        foreach (var id in libraryMovieIds)
+        var channelFolderIds = ChannelIdentity.GetAllChannelFolderIds(libraryManager).ToList();
+
+        // Trendings NUNCA muestra episodios en la fila del home: Jellyfin materializa shadows de
+        // episodio al navegar a una temporada del canal, y la row del home los aplana (los trata
+        // como items latest). Se limpian en cada sync (arranque + sincronizaciones) para que la
+        // row quede con películas y series, nunca episodios.
+        await CleanupEpisodeShadowsAsync(libraryManager, logger, cancellationToken).ConfigureAwait(false);
+
+        foreach (var entry in cacheEntries)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            if (entry.ItemId == Guid.Empty)
+            {
+                continue;
+            }
+
+            try
+            {
+                // Resolución canónica: el GUID de librería es fast-path; si quedó stale (librería
+                // re-importada/migrada) se re-matchea por TMDB al item actual de librería para copiar
+                // metadatos/reparto/imágenes correctos a la sombra.
+                var library = TrendingItemResolver.ResolveCurrentItem(
+                    libraryManager, entry.ItemId, entry.TmdbId, entry.MediaType == TrendingMediaType.Series);
+                if (library is null)
+                {
+                    continue;
+                }
+
+                await SyncLibraryItemAsync(libraryManager, channelFolderIds, library, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "JellyTrend: no se pudo sincronizar metadatos del sombra para {ItemId}.", entry.ItemId);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Synchronizes shadows for raw library item ids (recommendations storage), resolving each id
+    /// directly without TMDB re-matching.
+    /// </summary>
+    /// <param name="libraryManager">Instance of the <see cref="ILibraryManager"/> interface.</param>
+    /// <param name="libraryItemIds">The library item ids (movies and series) to sync.</param>
+    /// <param name="logger">The logger.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    public static async Task SyncAllAsync(
+        ILibraryManager libraryManager,
+        IReadOnlyList<Guid> libraryItemIds,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var channelFolderIds = ChannelIdentity.GetAllChannelFolderIds(libraryManager).ToList();
+
+        await CleanupEpisodeShadowsAsync(libraryManager, logger, cancellationToken).ConfigureAwait(false);
+
+        foreach (var id in libraryItemIds)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (id == Guid.Empty)
+            {
+                continue;
+            }
+
             try
             {
                 var library = libraryManager.GetItemById(id);
@@ -45,13 +112,7 @@ public static class TrendingShadowMetadataSync
                     continue;
                 }
 
-                var shadow = FindShadowMovie(libraryManager, id);
-                if (shadow is null)
-                {
-                    continue;
-                }
-
-                await SyncOneAsync(libraryManager, library, shadow, cancellationToken).ConfigureAwait(false);
+                await SyncLibraryItemAsync(libraryManager, channelFolderIds, library, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -60,15 +121,115 @@ public static class TrendingShadowMetadataSync
         }
     }
 
+    private static async Task SyncLibraryItemAsync(
+        ILibraryManager libraryManager,
+        IReadOnlyList<Guid> channelFolderIds,
+        BaseItem library,
+        CancellationToken cancellationToken)
+    {
+        foreach (var channelFolderId in channelFolderIds)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var shadow = FindChannelShadow(libraryManager, channelFolderId, library, library.Id);
+            if (shadow is null)
+            {
+                continue;
+            }
+
+            await SyncOneAsync(libraryManager, library, shadow, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
     /// <summary>
-    /// Finds the channel shadow item associated with a library movie.
+    /// Deletes the Episode shadow items persisted inside the JellyTrend channels. Episodes are
+    /// materialized by Jellyfin when a client browses into a series season of the channel; the home
+    /// "latest" row flattens all non-folder channel shadows, so those episodes would pollute the
+    /// trending row. Trending must NEVER show episodes, so they are removed on every sync.
     /// </summary>
     /// <param name="libraryManager">Instance of the <see cref="ILibraryManager"/> interface.</param>
+    /// <param name="logger">The logger.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    public static async Task CleanupEpisodeShadowsAsync(
+        ILibraryManager libraryManager,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var channelFolderIds = ChannelIdentity.GetAllChannelFolderIds(libraryManager).ToList();
+
+        foreach (var channelFolderId in channelFolderIds)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var episodes = libraryManager.GetItemList(new InternalItemsQuery
+            {
+                ChannelIds = new[] { channelFolderId },
+                IncludeItemTypes = new[] { BaseItemKind.Episode }
+            });
+
+            if (episodes.Count == 0)
+            {
+                continue;
+            }
+
+            foreach (var episode in episodes)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var options = new DeleteOptions { DeleteFileLocation = false, DeleteFromExternalProvider = false };
+                var parent = episode.ParentId != Guid.Empty ? libraryManager.GetItemById(episode.ParentId) : null;
+                if (parent is not null)
+                {
+                    libraryManager.DeleteItem(episode, options, parent, false);
+                }
+                else
+                {
+                    libraryManager.DeleteItem(episode, options);
+                }
+            }
+
+            logger.LogDebug("JellyTrend: {Count} episodios sombra eliminados del canal {ChannelId}.", episodes.Count, channelFolderId);
+        }
+    }
+
+    /// <summary>
+    /// Finds the channel shadow item for a library movie or series inside a specific JellyTrend channel.
+    /// </summary>
+    /// <param name="libraryManager">Instance of the <see cref="ILibraryManager"/> interface.</param>
+    /// <param name="channelFolderId">The JellyTrend channel folder id to search in.</param>
+    /// <param name="library">The library item (movie or series).</param>
+    /// <param name="libraryId">The library item id.</param>
+    /// <returns>The shadow item, or <c>null</c> if not found.</returns>
+    private static BaseItem? FindChannelShadow(
+        ILibraryManager libraryManager,
+        Guid channelFolderId,
+        BaseItem library,
+        Guid libraryId)
+    {
+        var kind = library is Series ? BaseItemKind.Series : BaseItemKind.Movie;
+        var query = new InternalItemsQuery
+        {
+            ChannelIds = new[] { channelFolderId },
+            ExternalId = libraryId.ToString("D"),
+            IncludeItemTypes = new[] { kind },
+            Limit = 1
+        };
+
+        var items = libraryManager.GetItemList(query);
+        return items.Count > 0 ? items[0] : null;
+    }
+
+    /// <summary>
+    /// Finds the channel shadow item associated with a library movie inside a specific JellyTrend channel.
+    /// </summary>
+    /// <param name="libraryManager">Instance of the <see cref="ILibraryManager"/> interface.</param>
+    /// <param name="channelFolderId">The JellyTrend channel folder id to search in.</param>
     /// <param name="libraryMovieId">The library movie id.</param>
     /// <returns>The shadow movie, or <c>null</c> if not found.</returns>
-    public static BaseItem? FindShadowMovie(ILibraryManager libraryManager, Guid libraryMovieId)
+    public static BaseItem? FindShadowMovie(
+        ILibraryManager libraryManager,
+        Guid channelFolderId,
+        Guid libraryMovieId)
     {
-        var channelFolderId = ChannelIdentity.GetPluginChannelFolderId(libraryManager);
         var query = new InternalItemsQuery
         {
             ChannelIds = new[] { channelFolderId },
@@ -87,41 +248,285 @@ public static class TrendingShadowMetadataSync
         BaseItem shadow,
         CancellationToken cancellationToken)
     {
+        // Solo se persiste cuando algo cambió. Sin esto, cada sync reescribe TODAS las sombras
+        // (reparto + metadatos + imágenes) y con Postgres lento provoca timeouts que abortan
+        // parte del pase → series que se quedan sin imágenes.
+        var changed = false;
+
+        // Reparto: solo se reescribe si el sombra tiene menos reparto que la biblioteca.
         var people = libraryManager.GetPeople(library);
         if (people.Count > 0)
         {
-            await libraryManager.UpdatePeopleAsync(shadow, people, cancellationToken).ConfigureAwait(false);
+            var shadowPeople = libraryManager.GetPeople(shadow);
+            if (shadowPeople.Count < people.Count)
+            {
+                await libraryManager.UpdatePeopleAsync(shadow, people, cancellationToken).ConfigureAwait(false);
+                changed = true;
+            }
         }
 
-        shadow.Name = library.Name;
-        shadow.OriginalTitle = library.OriginalTitle;
-        shadow.Overview = library.Overview;
-        shadow.OfficialRating = library.OfficialRating;
-        shadow.CommunityRating = library.CommunityRating;
-        shadow.CriticRating = library.CriticRating;
-        shadow.ProductionYear = library.ProductionYear;
-        shadow.PremiereDate = library.PremiereDate;
-        shadow.DateCreated = library.DateCreated;
-        shadow.Genres = library.Genres?.ToArray() ?? Array.Empty<string>();
-        shadow.Studios = library.Studios?.ToArray() ?? Array.Empty<string>();
-        shadow.Tags = library.Tags?.ToArray() ?? Array.Empty<string>();
-        shadow.ProviderIds = new Dictionary<string, string>(library.ProviderIds, StringComparer.OrdinalIgnoreCase);
+        changed |= SyncCoreMetadata(shadow, library);
+        changed |= SyncCollections(shadow, library);
+        changed |= SyncNumericFields(shadow, library);
 
         if (library is Video libVideo && shadow is Video shVideo)
         {
-            shVideo.Tagline = libVideo.Tagline;
-            shVideo.RunTimeTicks = libVideo.RunTimeTicks ?? shVideo.RunTimeTicks;
+            changed |= SyncVideoMetadata(shVideo, libVideo);
         }
 
+        var imagesBefore = shadow.ImageInfos.Length;
         CopyImages(library, shadow);
-
-        var parent = libraryManager.GetItemById(shadow.ParentId);
-        if (parent is not null)
+        if (shadow.ImageInfos.Length != imagesBefore)
         {
-            await libraryManager
-                .UpdateItemAsync(shadow, parent, ItemUpdateType.MetadataEdit | ItemUpdateType.ImageUpdate, cancellationToken)
-                .ConfigureAwait(false);
+            changed = true;
         }
+
+        // Asegurar que el sombra quede como item virtual (sin Path local heredado de versiones
+        // anteriores que embebían MediaSources y lo volvían LocationType FileSystem).
+        if (shadow.Path is not null)
+        {
+            shadow.Path = null;
+            changed = true;
+        }
+
+        // Los items sombra del canal pueden quedar huérfanos (ParentId vacío) tras cambios
+        // de versión; GetItemById no acepta Guid.Empty, así que solo se persiste cuando hay
+        // un parent real y hubo cambios.
+        if (changed && shadow.ParentId != Guid.Empty)
+        {
+            var parent = libraryManager.GetItemById(shadow.ParentId);
+            if (parent is not null)
+            {
+                await libraryManager
+                    .UpdateItemAsync(shadow, parent, ItemUpdateType.MetadataEdit | ItemUpdateType.ImageUpdate, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+        }
+    }
+
+    private static bool SyncCoreMetadata(BaseItem shadow, BaseItem library)
+    {
+        var changed = false;
+        if (shadow.Name != library.Name)
+        {
+            shadow.Name = library.Name;
+            changed = true;
+        }
+
+        if (shadow.OriginalTitle != library.OriginalTitle)
+        {
+            shadow.OriginalTitle = library.OriginalTitle;
+            changed = true;
+        }
+
+        if (shadow.Overview != library.Overview)
+        {
+            shadow.Overview = library.Overview;
+            changed = true;
+        }
+
+        if (shadow.OfficialRating != library.OfficialRating)
+        {
+            shadow.OfficialRating = library.OfficialRating;
+            changed = true;
+        }
+
+        if (shadow.Container != library.Container)
+        {
+            shadow.Container = library.Container;
+            changed = true;
+        }
+
+        if (shadow.HomePageUrl != library.HomePageUrl)
+        {
+            shadow.HomePageUrl = library.HomePageUrl;
+            changed = true;
+        }
+
+        if (shadow.CustomRating != library.CustomRating)
+        {
+            shadow.CustomRating = library.CustomRating;
+            changed = true;
+        }
+
+        return changed;
+    }
+
+    private static bool SyncCollections(BaseItem shadow, BaseItem library)
+    {
+        var changed = false;
+        if (!SameStrings(shadow.Genres, library.Genres))
+        {
+            shadow.Genres = library.Genres?.ToArray() ?? Array.Empty<string>();
+            changed = true;
+        }
+
+        if (!SameStrings(shadow.Studios, library.Studios))
+        {
+            shadow.Studios = library.Studios?.ToArray() ?? Array.Empty<string>();
+            changed = true;
+        }
+
+        if (!SameStrings(shadow.Tags, library.Tags))
+        {
+            shadow.Tags = library.Tags?.ToArray() ?? Array.Empty<string>();
+            changed = true;
+        }
+
+        if (!SameStrings(shadow.ProductionLocations, library.ProductionLocations))
+        {
+            shadow.ProductionLocations = library.ProductionLocations?.ToArray() ?? Array.Empty<string>();
+            changed = true;
+        }
+
+        if (!SameProviderIds(shadow.ProviderIds, library.ProviderIds))
+        {
+            shadow.ProviderIds = new Dictionary<string, string>(library.ProviderIds, StringComparer.OrdinalIgnoreCase);
+            changed = true;
+        }
+
+        return changed;
+    }
+
+    private static bool SyncNumericFields(BaseItem shadow, BaseItem library)
+    {
+        var changed = false;
+        if (!Equals(shadow.CommunityRating, library.CommunityRating))
+        {
+            shadow.CommunityRating = library.CommunityRating;
+            changed = true;
+        }
+
+        if (!Equals(shadow.CriticRating, library.CriticRating))
+        {
+            shadow.CriticRating = library.CriticRating;
+            changed = true;
+        }
+
+        if (shadow.ProductionYear != library.ProductionYear)
+        {
+            shadow.ProductionYear = library.ProductionYear;
+            changed = true;
+        }
+
+        if (shadow.PremiereDate != library.PremiereDate)
+        {
+            shadow.PremiereDate = library.PremiereDate;
+            changed = true;
+        }
+
+        if (shadow.DateCreated != library.DateCreated)
+        {
+            shadow.DateCreated = library.DateCreated;
+            changed = true;
+        }
+
+        if (shadow.Width != library.Width)
+        {
+            shadow.Width = library.Width;
+            changed = true;
+        }
+
+        if (shadow.Height != library.Height)
+        {
+            shadow.Height = library.Height;
+            changed = true;
+        }
+
+        if (shadow.TotalBitrate != library.TotalBitrate)
+        {
+            shadow.TotalBitrate = library.TotalBitrate;
+            changed = true;
+        }
+
+        return changed;
+    }
+
+    private static bool SyncVideoMetadata(Video shadow, Video library)
+    {
+        var changed = false;
+        if (shadow.Tagline != library.Tagline)
+        {
+            shadow.Tagline = library.Tagline;
+            changed = true;
+        }
+
+        if (library.RunTimeTicks.HasValue && shadow.RunTimeTicks != library.RunTimeTicks)
+        {
+            shadow.RunTimeTicks = library.RunTimeTicks;
+            changed = true;
+        }
+
+        if (shadow.HasSubtitles != library.HasSubtitles)
+        {
+            shadow.HasSubtitles = library.HasSubtitles;
+            changed = true;
+        }
+
+        if (shadow.VideoType != library.VideoType)
+        {
+            shadow.VideoType = library.VideoType;
+            changed = true;
+        }
+
+        if (shadow.Video3DFormat != library.Video3DFormat)
+        {
+            shadow.Video3DFormat = library.Video3DFormat;
+            changed = true;
+        }
+
+        if (shadow.Timestamp != library.Timestamp)
+        {
+            shadow.Timestamp = library.Timestamp;
+            changed = true;
+        }
+
+        if (shadow.DefaultVideoStreamIndex != library.DefaultVideoStreamIndex)
+        {
+            shadow.DefaultVideoStreamIndex = library.DefaultVideoStreamIndex;
+            changed = true;
+        }
+
+        if (shadow.AspectRatio != library.AspectRatio)
+        {
+            shadow.AspectRatio = library.AspectRatio;
+            changed = true;
+        }
+
+        return changed;
+    }
+
+    private static bool SameStrings(string[]? a, string[]? b)
+    {
+        if (ReferenceEquals(a, b))
+        {
+            return true;
+        }
+
+        if (a is null || b is null)
+        {
+            return false;
+        }
+
+        return a.SequenceEqual(b, StringComparer.Ordinal);
+    }
+
+    private static bool SameProviderIds(Dictionary<string, string> a, Dictionary<string, string> b)
+    {
+        if (a.Count != b.Count)
+        {
+            return false;
+        }
+
+        foreach (var pair in a)
+        {
+            if (!b.TryGetValue(pair.Key, out var value) || !string.Equals(value, pair.Value, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /// <summary>

--- a/Jellyfin.Plugin.JellyTrend/Web/jellyTrend.css
+++ b/Jellyfin.Plugin.JellyTrend/Web/jellyTrend.css
@@ -36,6 +36,10 @@
     width: 100%;
     height: var(--jt-height);
     overflow: hidden;
+    /* El banner maneja los gestos HORIZONTALES (cambiar de slide); el scroll
+       vertical de la página se deja al navegador/cliente. Así el swipe del
+       banner no dispara la navegación horizontal nativa de Jellyfin (Favoritos). */
+    touch-action: pan-y;
 }
 
 .jt-swiper .swiper-wrapper {
@@ -289,6 +293,17 @@
     /* Override Swiper's default pagination positioning */
     width: auto !important;
     left: auto !important;
+    /* Con muchos ítems la fila de bullets se desplaza en vez de desbordar el pie */
+    max-width: 55%;
+    overflow-x: auto;
+    scrollbar-width: none;
+}
+
+.jt-pagination::-webkit-scrollbar { display: none; }
+
+/* Contador compacto "n / total" — oculto en desktop, visible solo en móvil */
+.jt-count {
+    display: none;
 }
 
 .jt-bullet {
@@ -350,15 +365,45 @@
         font-size: .8rem;
     }
 
-    /* Paginación en su esquina, sin encimarse con los botones */
+    /* Paginación: en móvil los bullets se sustituyen por un contador compacto
+       "n / total" para que el pie no se sature con la cantidad de ítems. */
     .jt-pagination {
-        bottom: .6em;
-        right: .7em;
+        display: none;
     }
 
+    .jt-count {
+        display: inline-flex;
+        align-items: center;
+        position: absolute;
+        bottom: .7em;
+        right: .9em;
+        z-index: 10;
+        font-size: .78rem;
+        font-weight: 600;
+        font-variant-numeric: tabular-nums;
+        color: var(--jt-text-muted);
+        background: rgba(0,0,0,.35);
+        padding: .25em .8em;
+        border-radius: 999px;
+        backdrop-filter: blur(4px);
+        -webkit-backdrop-filter: blur(4px);
+        pointer-events: none;
+    }
+
+    /* Flechas visibles y táctiles en móvil (área ≥ 44px) para poder pasar de
+       contenido sin depender del swipe */
     .jt-prev,
     .jt-next {
-        display: none;
+        width: 2.75rem;
+        height: 3.5rem;
+        background: rgba(0,0,0,.30);
+    }
+
+    .jt-prev::before,
+    .jt-next::before {
+        width: .5rem;
+        height: .5rem;
+        border-width: 2px;
     }
 
     /* On small screens, use a bottom-up gradient instead of side gradient */

--- a/Jellyfin.Plugin.JellyTrend/Web/jellyTrend.js
+++ b/Jellyfin.Plugin.JellyTrend/Web/jellyTrend.js
@@ -306,6 +306,20 @@
     };
 
     // ── Swiper config ────────────────────────────────────────────────────────
+    // Actualiza el contador compacto "n / total" del pie (visible en móvil).
+    function updateCounter(swiperEl, current, total) {
+        const count = swiperEl.querySelector('.jt-count');
+        if (count) count.textContent = `${current} / ${total}`;
+    }
+
+    // En loop, Swiper añade clones con la clase swiper-slide-duplicate; se filtran
+    // para contar solo las diapositivas reales. realIndex ya es el índice real.
+    function updateSwiperCounter(swiper) {
+        const total = Array.from(swiper.slides || [])
+            .filter(s => !s.classList.contains('swiper-slide-duplicate')).length;
+        updateCounter(swiper.el, swiper.realIndex + 1, total);
+    }
+
     const SWIPER_OPTIONS = {
         loop: true,
         speed: 900,
@@ -320,7 +334,12 @@
             bulletActiveClass: 'jt-bullet-active',
             renderBullet: (_i, cls) => `<button class="${cls}" aria-label="Go to slide"></button>`
         },
-        keyboard: { enabled: true }
+        keyboard: { enabled: true },
+        touchMoveStopPropagation: true,
+        on: {
+            init: updateSwiperCounter,
+            slideChange: updateSwiperCounter
+        }
     };
 
     // ── HTML builders ─────────────────────────────────────────────────────────
@@ -332,6 +351,7 @@
     <button class="jt-prev swiper-button-prev" aria-label="Previous slide"></button>
     <button class="jt-next swiper-button-next" aria-label="Next slide"></button>
     <div class="jt-pagination swiper-pagination" role="tablist" aria-label="Slides"></div>
+    <div class="jt-count" aria-live="polite"></div>
   </div>
 </section>`;
     }
@@ -380,6 +400,8 @@
             this._bullets = [];
             this._idx    = 0;
             this._timer  = null;
+            this._touchX = null;
+            this._touchY = null;
             this._init();
         }
 
@@ -409,6 +431,40 @@
                 if (e.key === 'ArrowRight') this._step(+1);
             });
 
+            // Touch swipe: el gesto HORIZONTAL lo reclamamos para el carrusel y NO debe
+            // llegar a Jellyfin (su swipe nativo derecha→izquierda cambia a Favoritos).
+            // stopPropagation impide que el evento burbujee a los handlers del cliente;
+            // preventDefault (solo en movimiento horizontal) evita el scroll/panning del
+            // navegador. El scroll VERTICAL de la página sigue intacto.
+            this._el.addEventListener('touchstart', (e) => {
+                e.stopPropagation();
+                if (e.touches.length !== 1) return;
+                this._touchX = e.touches[0].clientX;
+                this._touchY = e.touches[0].clientY;
+            }, { passive: true });
+            this._el.addEventListener('touchmove', (e) => {
+                e.stopPropagation();
+                if (this._touchX === null || e.touches.length !== 1) return;
+                const dx = e.touches[0].clientX - this._touchX;
+                const dy = e.touches[0].clientY - this._touchY;
+                if (Math.abs(dx) > 24 && Math.abs(dx) > Math.abs(dy) * 1.2) {
+                    e.preventDefault();
+                    this._touchX = e.touches[0].clientX;
+                    this._touchY = e.touches[0].clientY;
+                }
+            }, { passive: false });
+            this._el.addEventListener('touchend', (e) => {
+                e.stopPropagation();
+                if (this._touchX === null) return;
+                const dx = e.changedTouches[0].clientX - this._touchX;
+                const dy = e.changedTouches[0].clientY - this._touchY;
+                this._touchX = null;
+                this._touchY = null;
+                if (Math.abs(dx) > 40 && Math.abs(dx) > Math.abs(dy) * 1.2) {
+                    this._step(dx < 0 ? 1 : -1);
+                }
+            });
+
             this._goTo(0, false);
             this._startTimer();
         }
@@ -423,6 +479,7 @@
                 b.classList.toggle('jt-bullet-active', i === this._idx);
                 b.setAttribute('aria-selected', String(i === this._idx));
             });
+            updateCounter(this._el, this._idx + 1, this._slides.length);
             if (resetTimer) this._resetTimer();
         }
 

--- a/README.en.md
+++ b/README.en.md
@@ -338,6 +338,34 @@ dotnet build Jellyfin.Plugin.JellyTrend.sln -c Release   # must report 0 warning
 
 ---
 
+## 📜 Version history
+
+### v2.0.2 — Channel content fixed
+
+Fixes on top of **2.0.1** (completing the work started in **2.0.0**):
+
+**Content and playback (the main issue)**
+- **Series seasons work again**: the TMDB match could return the channel *shadow* instead of the real library item (the `IsVirtualItem` filter does not exclude them on Postgres), leaving series folders empty and unplayable. Resolution now excludes channel items and validates the type.
+- **Stable identity by TMDB**: the library GUID is volatile (it changes when the library is re-imported or the database is migrated). When the stored GUID no longer exists, the plugin re-matches by TMDB id so series keep navigating to their seasons and movies stay playable.
+- **Never episodes in the Trending row**: episode shadows are cleaned on every sync.
+- **Series local images**: the sync now copies the library images to series shadows too (previously only movies).
+- **Optimized sync**: only persists when something changed → subsequent syncs are much faster and avoid Postgres timeouts.
+
+**Recommended**
+- Channel aligned with Trending: per-user cache, already-watched filter, local images and metadata.
+
+**Settings**
+- Removed the sync intervals from the config page (now managed under *Dashboard → Tasks*).
+- New **“Show TV series in Trending”** checkbox applied to the channel, the home row and the banner.
+
+**Mobile banner**
+- Fixed horizontal swipe (no longer triggers the Favorites menu) and counter pagination on mobile.
+
+**Logging**
+- Dedicated logger with a monthly file `log/JellyTrend-YYYYMM.log`.
+
+---
+
 ## 🤝 Community
 
 Found a bug or have a suggestion? Open an [issue](https://github.com/BORNIOS/JellyTrend/issues) or join the official Jellyfin community:

--- a/README.md
+++ b/README.md
@@ -341,6 +341,34 @@ dotnet build Jellyfin.Plugin.JellyTrend.sln -c Release   # debe reportar 0 warni
 
 ---
 
+## 📜 Historial de versiones
+
+### v2.0.2 — Contenido de canales corregido
+
+Correcciones sobre la base de **2.0.1** (y cierre del trabajo iniciado en **2.0.0**):
+
+**Contenido y reproducción (el problema principal)**
+- **Series con temporadas de nuevo**: el emparejamiento por TMDB podía devolver la *sombra* del canal en lugar del ítem real de la librería (el filtro `IsVirtualItem` no las excluye con Postgres), dejando carpetas de serie vacías y sin reproducción. Ahora la resolución excluye los ítems de canal y valida el tipo.
+- **Identidad estable por TMDB**: el GUID de librería es volátil (cambia al re-importar o migrar la base de datos). Cuando el GUID guardado ya no existe, el plugin re-matchea por TMDB id, así las series siguen navegando a sus temporadas y las películas siguen siendo reproducibles.
+- **Jamás episodios en la fila de Trendings**: se limpian los sombras de episodio en cada sincronización.
+- **Imágenes locales de series**: el sync copia las imágenes de la biblioteca también a las sombras de serie (antes solo películas).
+- **Sync optimizado**: solo persiste cuando hay cambios → el segundo sync en adelante es mucho más rápido y evita los timeouts de Postgres.
+
+**Recomendados**
+- Canal alineado con Trendings: caché por usuario, filtro de ya vistos, imágenes y metadatos locales.
+
+**Configuración**
+- Eliminados los intervalos de la página de configuración (ahora se gestionan en *Dashboard → Tareas*).
+- Nuevo checkbox **«Mostrar series en Trendings»** aplicado al canal, la fila del home y el banner.
+
+**Banner móvil**
+- Swipe horizontal corregido (ya no dispara el menú de Favoritos) y paginación por contador en móvil.
+
+**Logs**
+- Logger propio con archivo mensual `log/JellyTrend-YYYYMM.log`.
+
+---
+
 ## 🤝 Comunidad
 
 ¿Dudas, sugerencias o has encontrado un bug? Abre un [issue](https://github.com/BORNIOS/JellyTrend/issues) o únete a la comunidad oficial de Jellyfin:


### PR DESCRIPTION
# Release 2.0.2 — Contenido de canales corregido

## Correcciones sobre la base de 2.0.1 (cierre del trabajo iniciado en 2.0.0)

**Contenido y reproducción (el problema principal)**
- Series con temporadas de nuevo: el emparejamiento por TMDB podía devolver la *sombra* del canal en lugar del ítem real de la librería (el filtro IsVirtualItem no las excluye con Postgres). Ahora la resolución excluye los ítems de canal y valida el tipo.
- Identidad estable por TMDB: re-match por TMDB id cuando el GUID de librería quedó stale (re-import/migración de DB).
- Jamás episodios en la fila de Trendings; imágenes locales también para series.
- Sync de sombras optimizado (solo persiste cambios) y logger propio mensual.

**Configuración / Banner / Logs**
- Intervalos fuera de la config (Dashboard → Tareas) + checkbox «Mostrar series en Trendings».
- Banner móvil: swipe corregido y paginación por contador.
- Logger propio mensual log/JellyTrend-YYYYMM.log.